### PR TITLE
Hide control button if current permissions have no full access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+
+- Hiding admin control elements for token wihout full access, [PR-49](https://github.com/reductstore/web-console/pull/49)
+
 ## [1.1.1] - 2022-12-18
 
 ### Changed:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:17 AS builder
+FROM node:18 AS builder
 
-RUN npm install -g npm@8.12.2
+RUN npm install -g npm@9.3.1
 
 WORKDIR /app
 COPY package.json .

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "react-dom": "^17.0.0",
         "react-router-dom": "^5.3.3",
         "react-scripts": "5.0.1",
-        "reduct-js": "^1.1.1",
+        "reduct-js": "^1.2.0",
         "stream-browserify": "^3.0.0",
         "ts-jest": "^27.1.4",
         "typescript": "^4.6.3",
@@ -16127,9 +16127,9 @@
       }
     },
     "node_modules/reduct-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.1.1.tgz",
-      "integrity": "sha512-vEmUTUuVZwUTSsEbL8k4SyUG3NUEB3rejVF4lnQWFKinbXHb2V0FW1VcWVEdV6u/dPaz7zMBCl7HpOvIMuJYEA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.2.0.tgz",
+      "integrity": "sha512-eykpEzeDFG/tqIQwpudwDt2wTWV90vJAJG+yCmh1LfrSe21Nm0fwTSAhvFy8oNWCt2t/u9MRB0CDEcLivtYJVw==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2"
@@ -30954,9 +30954,9 @@
       }
     },
     "reduct-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.1.1.tgz",
-      "integrity": "sha512-vEmUTUuVZwUTSsEbL8k4SyUG3NUEB3rejVF4lnQWFKinbXHb2V0FW1VcWVEdV6u/dPaz7zMBCl7HpOvIMuJYEA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reduct-js/-/reduct-js-1.2.0.tgz",
+      "integrity": "sha512-eykpEzeDFG/tqIQwpudwDt2wTWV90vJAJG+yCmh1LfrSe21Nm0fwTSAhvFy8oNWCt2t/u9MRB0CDEcLivtYJVw==",
       "dev": true,
       "requires": {
         "axios": "^0.27.2"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^17.0.0",
     "react-router-dom": "^5.3.3",
     "react-scripts": "5.0.1",
-    "reduct-js": "^1.1.1",
+    "reduct-js": "^1.2.0",
     "ts-jest": "^27.1.4",
     "typescript": "^4.6.3",
     "web-vitals": "^2.1.4",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -16,6 +16,7 @@ describe("App", () => {
         logout: jest.fn(),
         login: jest.fn(),
         isAllowed: jest.fn(),
+        me: jest.fn(),
     };
 
     const routeProps = makeRouteProps();

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,7 +6,7 @@ import {MemoryRouter} from "react-router-dom";
 
 import App from "./App";
 import {IBackendAPI} from "./BackendAPI";
-import {Client} from "reduct-js";
+import {Client, Token} from "reduct-js";
 
 
 describe("App", () => {
@@ -38,5 +38,30 @@ describe("App", () => {
         // @ts-ignore
         bucketItem.props().onClick();
         expect(routeProps.history.push).toBeCalledWith("/buckets");
+    });
+
+    it("should have a link to security panel", async () => {
+        backendAPI.isAllowed = jest.fn().mockResolvedValue(true);
+        backendAPI.me = jest.fn().mockResolvedValue({permissions: {fullAccess: true}} as Token);
+        routeProps.history.push = jest.fn();
+
+        const app = mount(<MemoryRouter><App {...routeProps}
+                                             backendApi={backendAPI}/></MemoryRouter>);
+
+        const bucketItem = (await waitUntilFind(app, "#Security")).hostNodes().at(0);
+        // @ts-ignore
+        bucketItem.props().onClick();
+        expect(routeProps.history.push).toBeCalledWith("/tokens");
+    });
+
+    it("should hide security panel", async () => {
+        backendAPI.isAllowed = jest.fn().mockResolvedValue(true);
+        backendAPI.me = jest.fn().mockResolvedValue({permissions: {fullAccess: false}} as Token);
+
+        const app = mount(<MemoryRouter><App {...routeProps}
+                                             backendApi={backendAPI}/></MemoryRouter>);
+
+        const bucketItem = (await waitUntilFind(app, "#Security"));
+        expect(bucketItem).toBeUndefined();
     });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import "./App.css";
 import {IBackendAPI} from "./BackendAPI";
 import {Routes} from "./Components/Routes";
 import {BorderOuterOutlined, DatabaseOutlined, LockOutlined, LogoutOutlined} from "@ant-design/icons";
+import {TokenPermissions} from "reduct-js";
 
 ConfigProvider.config({
     theme: {
@@ -21,38 +22,39 @@ interface Props extends RouteComponentProps {
 }
 
 type State = {
-    isAllowed?: boolean;
+    permissions?: TokenPermissions
 }
 
 export default class App extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
-        this.state = {};
+        this.state = {permissions: {fullAccess: false}};
     }
 
     componentDidMount() {
         this.props.backendApi.isAllowed()
-            .then((isAllowed) => this.setState({isAllowed}))
+            .then((isAllowed) => {
+                return isAllowed ? this.props.backendApi.me() : undefined;
+            })
+            .then((token) => this.setState({permissions: (token && token.permissions) ?? undefined}))
             .catch((err) => console.error(err));
     }
 
     render() {
-        if (this.state.isAllowed === undefined) {
-            return <div/>;
-        }
-
         const {backendApi, history} = this.props;
         const onLogout = async () => {
             backendApi.logout();
-            this.setState({isAllowed: false});
+            this.setState({permissions: undefined});
         };
 
         const onLogin = async () => {
-            this.setState({isAllowed: true});
+            this.setState({permissions: (await this.props.backendApi.me()).permissions});
             this.props.history.push("/");
         };
 
         const version = process.env.REACT_APP_VERSION;
+        const {permissions} = this.state;
+
         return <div className="App">
             <Layout>
                 <Layout.Sider className="Sider">
@@ -62,7 +64,7 @@ export default class App extends React.Component<Props, State> {
                         </a>
 
                         <Divider/>
-                        {this.state.isAllowed ? <>
+                        {permissions ? <>
                                 <Menu.Item icon={<BorderOuterOutlined/>} onClick={() => history.push("/dashboard")}>
                                     Dashboard
                                 </Menu.Item>
@@ -71,7 +73,8 @@ export default class App extends React.Component<Props, State> {
                                     Buckets
                                 </Menu.Item>
 
-                                <Menu.Item id="Security" icon={<LockOutlined/>} onClick={() => history.push("/tokens")}>
+                                <Menu.Item hidden={!permissions.fullAccess} id="Security" icon={<LockOutlined/>}
+                                           onClick={() => history.push("/tokens")}>
                                     Security
                                 </Menu.Item>
                                 <Divider style={{borderColor: "white"}}/>
@@ -89,14 +92,13 @@ export default class App extends React.Component<Props, State> {
                             Version: v{version}
                         </div>
                     </div>
-
                 </Layout.Sider>
+
                 <Layout>
                     <Layout.Content>
-                        <Routes {...this.props} isAllowed={this.state.isAllowed} onLogin={onLogin}/>
-
+                        <Routes {...this.props} permissions={this.state.permissions}
+                                onLogin={onLogin}/>
                     </Layout.Content>
-
                 </Layout>
             </Layout>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,10 +73,12 @@ export default class App extends React.Component<Props, State> {
                                     Buckets
                                 </Menu.Item>
 
-                                <Menu.Item hidden={!permissions.fullAccess} id="Security" icon={<LockOutlined/>}
-                                           onClick={() => history.push("/tokens")}>
-                                    Security
-                                </Menu.Item>
+                                {permissions.fullAccess ?
+                                    <Menu.Item id="Security" icon={<LockOutlined/>}
+                                               onClick={() => history.push("/tokens")}>
+                                        Security
+                                    </Menu.Item>
+                                    : null}
                                 <Divider style={{borderColor: "white"}}/>
 
                                 <Menu.Item onClick={onLogout} icon={<LogoutOutlined/>}>

--- a/src/BackendAPI.ts
+++ b/src/BackendAPI.ts
@@ -1,10 +1,12 @@
-import {APIError, Client} from "reduct-js";
+import {APIError, Client, Token} from "reduct-js";
 
 export interface IBackendAPI {
     client: Client;
     login: (token: string) => Promise<void>;
     logout: () => void;
     isAllowed: () => Promise<boolean>;
+
+    me: () => Promise<Token>;
 }
 
 export class BackendAPI implements IBackendAPI {
@@ -57,5 +59,18 @@ export class BackendAPI implements IBackendAPI {
             throw err;
         }
 
+    }
+
+    async me(): Promise<Token> {
+        try {
+            return this.client.me();
+        } catch (err) {
+            if (err instanceof APIError && err.status == 401) {
+                sessionStorage.removeItem("apiToken");
+                return {name: "anonymous", createdAt: Date.now(), permissions: {fullAccess: false}};
+            }
+
+            throw err;
+        }
     }
 }

--- a/src/Components/Bucket/BucketCard.test.tsx
+++ b/src/Components/Bucket/BucketCard.test.tsx
@@ -17,7 +17,8 @@ describe("BucketCard", () => {
         const client = new Client("");
         const onRemove = jest.fn();
 
-        const wrapper = mount(<BucketCard bucketInfo={info} enablePanel client={client} index={0} onRemoved={onRemove} onShow={()=>null}/>);
+        const wrapper = mount(<BucketCard bucketInfo={info} permissions={{fullAccess: true}} enablePanel client={client}
+                                          index={0} onRemoved={onRemove} onShow={() => null}/>);
         const button = await waitUntilFind(wrapper, {title: "Settings"});
 
         button.hostNodes().simulate("click");

--- a/src/Components/Bucket/BucketCard.tsx
+++ b/src/Components/Bucket/BucketCard.tsx
@@ -50,10 +50,10 @@ export default function BucketCard(props: Readonly<Props>) {
 
     const actions = [];
     if (props.enablePanel) {
-        actions.push(<SettingOutlined key="setting" onClick={() => setChangeSettings(true)}/>);
+        actions.push(<SettingOutlined title="Settings" key="setting" onClick={() => setChangeSettings(true)}/>);
 
         if (props.permissions?.fullAccess) {
-            actions.push(<DeleteOutlined key="delete" style={{color: "red"}} onClick={() => setConfirmRemove(true)}/>);
+            actions.push(<DeleteOutlined title="Remove" key="delete" style={{color: "red"}} onClick={() => setConfirmRemove(true)}/>);
         }
     }
 

--- a/src/Components/Routes.tsx
+++ b/src/Components/Routes.tsx
@@ -8,53 +8,54 @@ import BucketList from "../Views/BucketPanel/BucketList";
 import BucketDetail from "../Views/BucketPanel/BucketDetail";
 import TokenList from "../Views/SecurityPanel/TokenList";
 import TokenDetail from "../Views/SecurityPanel/TokenDetail";
+import {TokenPermissions} from "reduct-js";
 
 interface Props extends RouteComponentProps {
     backendApi: IBackendAPI;
-    isAllowed: boolean;
     onLogin: () => void;
+    permissions?: TokenPermissions;
 }
 
 
 // @ts-ignore
-function PrivateRoute({children, isAllowed, ...rest}) {
+function PrivateRoute({children, authorized, ...rest}) {
     return (
         <Route {...rest} render={() => {
-            return isAllowed ? children : <Redirect to="/login"/>;
+            return authorized ? children : <Redirect to="/login"/>;
         }}/>
     );
 }
 
 export function Routes(props: Props): JSX.Element {
-    const {isAllowed} = props;
+    const authorized = props.permissions !== undefined;
 
     return (
         <Switch>
             <Route exact path="/">
-                {isAllowed ? <Redirect to="/dashboard"/> : <Redirect to="/login"/>}
+                {authorized ? <Redirect to="/dashboard"/> : <Redirect to="/login"/>}
             </Route>
 
             <Route exact path="/login">
                 <Login {...props}/>
             </Route>
 
-            <PrivateRoute exact path="/dashboard" isAllowed={isAllowed}>
+            <PrivateRoute exact path="/dashboard" authorized={authorized}>
                 <Dashboard {...props}/>
             </PrivateRoute>
 
-            <PrivateRoute exact path="/buckets" isAllowed={isAllowed}>
-                <BucketList client={props.backendApi.client}/>
+            <PrivateRoute exact path="/buckets" authorized={authorized}>
+                <BucketList client={props.backendApi.client} {...props}/>
             </PrivateRoute>
 
-            <PrivateRoute exact path="/buckets/:name" isAllowed={isAllowed}>
+            <PrivateRoute exact path="/buckets/:name" authorized={authorized}>
                 <BucketDetail client={props.backendApi.client} {...props}/>
             </PrivateRoute>
 
-            <PrivateRoute exact path="/tokens" isAllowed={isAllowed}>
+            <PrivateRoute exact path="/tokens" authorized={authorized && props.permissions?.fullAccess}>
                 <TokenList client={props.backendApi.client}/>
             </PrivateRoute>
 
-            <PrivateRoute exact path="/tokens/:name" isAllowed={isAllowed}>
+            <PrivateRoute exact path="/tokens/:name" authorized={authorized && props.permissions?.fullAccess}>
                 <TokenDetail client={props.backendApi.client}/>
             </PrivateRoute>
             <Route>

--- a/src/Helpers/TestHelpers.tsx
+++ b/src/Helpers/TestHelpers.tsx
@@ -37,13 +37,17 @@ export const mockJSDOM = () => {
 
 export const waitUntilFind = async (wrapper: ReactWrapper, predictor: any) => {
     let elements: any = [];
-    await waitUntil(() => {
-        act(() => {
-            // @ts-ignore
-            elements = wrapper.update().find(predictor);
-        });
-        return elements.length > 0;
-    });
+    try {
+        await waitUntil(() => {
+            act(() => {
+                // @ts-ignore
+                elements = wrapper.update().find(predictor);
+            });
+            return elements.length > 0;
+        }, {timeout: 1000});
+    } catch (e) {
+        return undefined;
+    }
 
     return elements;
 };

--- a/src/Views/Auth/Login.test.tsx
+++ b/src/Views/Auth/Login.test.tsx
@@ -21,6 +21,7 @@ describe("Auth::Login", () => {
         login: jest.fn(),
         logout: jest.fn(),
         isAllowed: jest.fn(),
+        me: jest.fn(),
     };
 
     const props = {

--- a/src/Views/BucketPanel/BucketDetail.test.tsx
+++ b/src/Views/BucketPanel/BucketDetail.test.tsx
@@ -74,7 +74,7 @@ describe("BucketDetail", () => {
 
 
     it("should remove bucket and redirect", async () => {
-        const detail = mount(<BucketDetail client={client}/>);
+        const detail = mount(<BucketDetail client={client} permissions={{fullAccess :true}}/>);
         const removeButton = await waitUntilFind(detail, {title: "Remove"});
 
         removeButton.hostNodes().props().onClick();
@@ -82,4 +82,10 @@ describe("BucketDetail", () => {
 
     });
 
+    it("should hide remove button if no permissions", async () => {
+        const detail = mount(<BucketDetail client={client} permissions={{fullAccess :false}}/>);
+        const removeButton = await waitUntilFind(detail, {title: "Remove"});
+
+        expect(removeButton).toBeUndefined();
+    });
 });

--- a/src/Views/BucketPanel/BucketDetail.tsx
+++ b/src/Views/BucketPanel/BucketDetail.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from "react";
-import {Bucket, BucketInfo, EntryInfo, Client} from "reduct-js";
+import {Bucket, BucketInfo, EntryInfo, Client, TokenPermissions} from "reduct-js";
 import {useHistory, useParams} from "react-router-dom";
 import BucketCard, {getHistory} from "../../Components/Bucket/BucketCard";
 // @ts-ignore
@@ -8,6 +8,7 @@ import {Table, Typography} from "antd";
 
 interface Props {
     client: Client;
+    permissions?: TokenPermissions;
 }
 
 
@@ -53,7 +54,7 @@ export default function BucketDetail(props: Readonly<Props>) {
     ];
 
     return <div style={{margin: "1.4em"}}>
-        {info ? <BucketCard bucketInfo={info} index={0} client={props.client}
+        {info ? <BucketCard bucketInfo={info} index={0} {...props}
                             enablePanel
                             onRemoved={() => history.push("/buckets")}
                             onShow={() => null}/> : <div/>}

--- a/src/Views/BucketPanel/BucketList.test.tsx
+++ b/src/Views/BucketPanel/BucketList.test.tsx
@@ -44,10 +44,19 @@ describe("BucketPanel", () => {
     });
 
     it("should add a new bucket", async () => {
-        const panel = mount(<MemoryRouter><BucketList client={client}/></MemoryRouter>);
+        const panel = mount(<MemoryRouter>
+            <BucketList client={client} permissions={{fullAccess: true}}/>
+        </MemoryRouter>);
         const button = await waitUntilFind(panel, {title: "Add"});
         expect(button).toBeDefined();
 
         // TODO: How to test modal?
+    });
+
+    it("should hide button to add a new bucket if user has no permissions", async () => {
+        const panel = mount(<MemoryRouter><BucketList client={client}
+                                                      permissions={{fullAccess: false}}/></MemoryRouter>);
+        const button = await waitUntilFind(panel, {title: "Add"});
+        expect(button).toBeUndefined();
     });
 });

--- a/src/Views/BucketPanel/BucketList.tsx
+++ b/src/Views/BucketPanel/BucketList.tsx
@@ -63,9 +63,10 @@ export default function BucketList(props: Readonly<Props>) {
     return <div style={{margin: "2em"}}>
         <Typography.Title level={3}>
             Buckets
-            <Button style={{float: "right"}} icon={<PlusOutlined/>}
-                    hidden={props.permissions === undefined || !props.permissions.fullAccess}
-                    onClick={() => setCreatingBucket(true)} title="Add"/>
+            {props.permissions?.fullAccess ?
+                <Button style={{float: "right"}} icon={<PlusOutlined/>}
+                        onClick={() => setCreatingBucket(true)} title="Add"/> : null}
+
             <Modal title="Add a new bucket" open={creatingBucket} footer={null}
                    onCancel={() => setCreatingBucket(false)}>
                 <CreateOrUpdate client={props.client}

--- a/src/Views/BucketPanel/BucketList.tsx
+++ b/src/Views/BucketPanel/BucketList.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from "react";
-import {BucketInfo, Client} from "reduct-js";
+import {BucketInfo, Client, TokenPermissions} from "reduct-js";
 import {Button, Modal, Table, Typography} from "antd";
 // @ts-ignore
 import prettierBytes from "prettier-bytes";
@@ -13,6 +13,7 @@ import CreateOrUpdate from "../../Components/Bucket/CreateOrUpdate";
 
 interface Props {
     client: Client;
+    permissions?: TokenPermissions;
 }
 
 
@@ -63,8 +64,9 @@ export default function BucketList(props: Readonly<Props>) {
         <Typography.Title level={3}>
             Buckets
             <Button style={{float: "right"}} icon={<PlusOutlined/>}
+                    hidden={props.permissions === undefined || !props.permissions.fullAccess}
                     onClick={() => setCreatingBucket(true)} title="Add"/>
-            <Modal title="Add a new bucket" visible={creatingBucket} footer={null}
+            <Modal title="Add a new bucket" open={creatingBucket} footer={null}
                    onCancel={() => setCreatingBucket(false)}>
                 <CreateOrUpdate client={props.client}
                                 onCreated={async () => {

--- a/src/Views/Dashboard/Dashboard.test.tsx
+++ b/src/Views/Dashboard/Dashboard.test.tsx
@@ -21,6 +21,7 @@ describe("Dashboard", () => {
         login: jest.fn(),
         logout: jest.fn(),
         isAllowed: jest.fn(),
+        me: jest.fn(),
     };
 
     const serverInfo: ServerInfo = {
@@ -61,7 +62,7 @@ describe("Dashboard", () => {
         client.getInfo = jest.fn().mockResolvedValue(serverInfo);
         client.getBucketList = jest.fn().mockResolvedValue([]);
 
-        const wrapper = mount(<Dashboard backendApi={backend}/>);
+        const wrapper = mount(<Dashboard backendApi={backend} permissions={{fullAccess: true}}/>);
         const html = (await waitUntilFind(wrapper, "#ServerInfo")).hostNodes();
 
         expect(html.text()).toContain("0.4.0");
@@ -70,7 +71,7 @@ describe("Dashboard", () => {
     });
 
     it("should show bucket info", async () => {
-        const wrapper = mount(<Dashboard backendApi={backend}/>);
+        const wrapper = mount(<Dashboard backendApi={backend} permissions={{fullAccess: true}}/>);
         const bucket = (await waitUntilFind(wrapper, "#bucket_1")).hostNodes();
         expect(bucket.text()).toContain("bucket_1");
         expect(bucket.text()).toContain("1 KB");
@@ -78,7 +79,7 @@ describe("Dashboard", () => {
     });
 
     it("should order buckets by last records", async () => {
-        const wrapper = mount(<Dashboard backendApi={backend}/>);
+        const wrapper = mount(<Dashboard backendApi={backend} permissions={{fullAccess: true}}/>);
         let bucket = (await waitUntilFind(wrapper, "#bucket_1"));
         expect(bucket.at(0).key()).toEqual("1");
 
@@ -87,7 +88,7 @@ describe("Dashboard", () => {
     });
 
     it("should push to BucketDetail if user click on bucket card", async () => {
-        const wrapper = mount(<Dashboard backendApi={backend}/>);
+        const wrapper = mount(<Dashboard backendApi={backend} permissions={{fullAccess: true}}/>);
         const bucket = (await waitUntilFind(wrapper, "#bucket_1")).hostNodes();
         bucket.props().onClick();
 

--- a/src/Views/Dashboard/Dashboard.tsx
+++ b/src/Views/Dashboard/Dashboard.tsx
@@ -105,7 +105,7 @@ export default function Dashboard(props: Readonly<Props>) {
         <Card bordered={true} id="ServerInfo" title={`Server v${info.version}`}
               actions={allowedActions}>
 
-            <Modal title="Add a new bucket" visible={creatingBucket} footer={null}
+            <Modal title="Add a new bucket" open={creatingBucket} footer={null}
                    onCancel={() => setCreatingBucket(false)}>
                 <CreateOrUpdate client={client}
                                 onCreated={async () => {

--- a/src/Views/Dashboard/Dashboard.tsx
+++ b/src/Views/Dashboard/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {IBackendAPI} from "../../BackendAPI";
-import {ServerInfo, BucketInfo} from "reduct-js";
+import {ServerInfo, BucketInfo, TokenPermissions} from "reduct-js";
 import humanizeDuration from "humanize-duration";
 // @ts-ignore
 import prettierBytes from "prettier-bytes";
@@ -15,6 +15,7 @@ import {History} from "history";
 
 interface Props {
     backendApi: IBackendAPI;
+    permissions?: TokenPermissions;
 }
 
 /**
@@ -94,12 +95,15 @@ export default function Dashboard(props: Readonly<Props>) {
         return rows;
     };
 
+    const allowedActions = [];
+    if (props.permissions && props.permissions.fullAccess) {
+        allowedActions.push(<PlusOutlined key="create" onClick={() => setCreatingBucket(true)}/>);
+    }
+
     const {client} = props.backendApi;
     return <div className="Panel">
         <Card bordered={true} id="ServerInfo" title={`Server v${info.version}`}
-              actions={[
-                  <PlusOutlined title="Add a new bucket" onClick={() => setCreatingBucket(true)}/>
-              ]}>
+              actions={allowedActions}>
 
             <Modal title="Add a new bucket" visible={creatingBucket} footer={null}
                    onCancel={() => setCreatingBucket(false)}>


### PR DESCRIPTION
Closes #48

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #48 

### What is the new behavior?

I check current permission with Client.me() method and hide the control buttons like create/remove a bucket, security panel, and tokens.

### Does this PR introduce a breaking change?

No

### Other information:
