### PR TITLE
RS-41: Remount entry confirmation component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- RS-41: Remount entry confirmation component, [PR-61](https://github.com/reductstore/web-console/pull/61)
+
 ## [1.4.0] - 2023-10-11
 
 ### Added:

--- a/src/Views/BucketPanel/BucketDetail.tsx
+++ b/src/Views/BucketPanel/BucketDetail.tsx
@@ -99,7 +99,7 @@ export default function BucketDetail(props: Readonly<Props>) {
 
         <Typography.Title level={3}>Entries</Typography.Title>
         <Table style={{margin: "0.6em"}} columns={columns} dataSource={data} loading={entries.length == 0}/>
-        <RemoveConfirmationByName name={entryToRemove} onRemoved={() => removeEntry(entryToRemove)}
+        <RemoveConfirmationByName key={entryToRemove} name={entryToRemove} onRemoved={() => removeEntry(entryToRemove)}
                                   onCanceled={() => setEntryToRemove("")} resourceType="entry"
                                   confirm={entryToRemove !== ""}/>
     </div>;


### PR DESCRIPTION
Closes #60 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #60 

### What is the new behavior?

I've set the  `key` property in the `RemoveConfirmationByName` component so that it is remounted for each entry.

### Does this PR introduce a breaking change?

No

### Other information:
