### PR TITLE
RS-554: Add hard quota to bucket settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-554: add forgotten HARD quota type to bucket settings, [PR-72](https://github.com/reductstore/web-console/pull/72)
+
 ## [1.8.0] - 2024-11-06
 
 ### Added

--- a/src/Components/Bucket/BucketSettingsForm.test.tsx
+++ b/src/Components/Bucket/BucketSettingsForm.test.tsx
@@ -313,4 +313,30 @@ describe("Bucket::BucketSettingsForm", () => {
     const inputEditable = wrapperEditable.find("#InputName").at(0);
     expect(inputEditable.props().disabled).toBeFalsy();
   });
+
+  it.each(["NONE", "FIFO", "HARD"])(
+    "should show all available quota types",
+    async (quotaType: string) => {
+      bucket.getSettings = jest.fn().mockResolvedValue({
+        maxBlockSize: 64_000_001n,
+        maxBlockRecords: 1024,
+        quotaSize: 1000n,
+        quotaType: QuotaType[quotaType as keyof typeof QuotaType],
+      });
+
+      const wrapper = mount(
+        <BucketSettingsForm
+          showAll
+          client={client}
+          bucketName={"bucket"}
+          onCreated={() => console.log("")}
+        />,
+      );
+
+      await waitUntilFind(wrapper, { name: "quotaType" });
+      const input = wrapper.find({ name: "quotaType" }).at(0);
+      console.log(input.debug());
+      expect(input.props().initialValue).toEqual(quotaType);
+    },
+  );
 });

--- a/src/Components/Bucket/BucketSettingsForm.tsx
+++ b/src/Components/Bucket/BucketSettingsForm.tsx
@@ -258,6 +258,7 @@ class BucketSettingsForm extends React.Component<
             <Select>
               <Option value="NONE">NONE</Option>
               <Option value="FIFO">FIFO</Option>
+              <Option value="HARD">HARD</Option>
             </Select>
           </Form.Item>
           <Form.Item


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?


The PR adds HARD quota to the bucket settings. I classify it as a bug because we forgot to add the type in the previous release.

### Related issues

[(Add links to related issues)
](https://github.com/reductstore/reductstore/pull/570)

### Does this PR introduce a breaking change?

No

### Other information:
