### PR TITLE
RS-582: Bug confirmation window doesn't appear after first bucket removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-582: fix state to ensure that the delete modal can reopen after removing a first bucket, [PR-75](https://github.com/reductstore/web-console/pull/75)
+
 ### [1.8.1] - 2024-12-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- RS-582: fix state to ensure that the delete modal can reopen after removing a first bucket, [PR-75](https://github.com/reductstore/web-console/pull/75)
+- RS-582: fix remove modal to display error messages, [PR-75](https://github.com/reductstore/web-console/pull/75)
 
 ### [1.8.1] - 2024-12-16
 

--- a/src/Components/Bucket/BucketCard.tsx
+++ b/src/Components/Bucket/BucketCard.tsx
@@ -54,6 +54,8 @@ export default function BucketCard(props: Readonly<Props>) {
       const bucket: Bucket = await client.getBucket(bucketInfo.name);
       await bucket.remove();
       props.onRemoved(bucketInfo.name);
+      setRemoveError(null);
+      setIsRemoveModalOpen(false);
     } catch (err) {
       console.error(err);
       if (err instanceof APIError && err.message) setRemoveError(err.message);

--- a/src/Components/Bucket/BucketCard.tsx
+++ b/src/Components/Bucket/BucketCard.tsx
@@ -1,7 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { Card, Col, Modal, Row, Statistic, Tag } from "antd";
 import humanizeDuration from "humanize-duration";
-import { Bucket, BucketInfo, Client, TokenPermissions } from "reduct-js";
+import {
+  APIError,
+  Bucket,
+  BucketInfo,
+  Client,
+  TokenPermissions,
+} from "reduct-js";
 
 // @ts-ignore
 import prettierBytes from "prettier-bytes";
@@ -33,8 +39,9 @@ export const getHistory = (interval: {
 };
 
 export default function BucketCard(props: Readonly<Props>) {
-  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [isRemoveModalOpen, setIsRemoveModalOpen] = useState(false);
   const [changeSettings, setChangeSettings] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
   const [bucketInfo, setBucketInfo] = useState(props.bucketInfo);
   const { client, index } = props;
 
@@ -43,9 +50,15 @@ export default function BucketCard(props: Readonly<Props>) {
   }, [props.bucketInfo]);
 
   const onRemove = async () => {
-    const bucket: Bucket = await client.getBucket(bucketInfo.name);
-    await bucket.remove();
-    props.onRemoved(bucketInfo.name);
+    try {
+      const bucket: Bucket = await client.getBucket(bucketInfo.name);
+      await bucket.remove();
+      props.onRemoved(bucketInfo.name);
+    } catch (err) {
+      console.error(err);
+      if (err instanceof APIError && err.message) setRemoveError(err.message);
+      else setRemoveError("Failed to remove bucket.");
+    }
   };
 
   const actions = [];
@@ -65,7 +78,7 @@ export default function BucketCard(props: Readonly<Props>) {
           title="Remove"
           key="delete"
           style={{ color: "red" }}
-          onClick={() => setConfirmRemove(true)}
+          onClick={() => setIsRemoveModalOpen(true)}
         />,
       );
     }
@@ -112,9 +125,13 @@ export default function BucketCard(props: Readonly<Props>) {
       <RemoveConfirmationModal
         name={bucketInfo.name}
         onRemove={onRemove}
-        onCancel={() => setConfirmRemove(false)}
-        confirm={confirmRemove}
+        onCancel={() => {
+          setIsRemoveModalOpen(false);
+          setRemoveError(null);
+        }}
+        open={isRemoveModalOpen}
         resourceType="bucket"
+        errorMessage={removeError}
       />
       <Modal
         title="Settings"

--- a/src/Components/LicenseDetails/LicenseDetails.test.tsx
+++ b/src/Components/LicenseDetails/LicenseDetails.test.tsx
@@ -9,7 +9,7 @@ describe("LicenseDetails", () => {
     plan: "Pro",
     licensee: "Acme Corp",
     invoice: "INV-123",
-    expiryDate: 1735689600000,
+    expiryDate: 5000000000000,
     deviceNumber: 100,
     diskQuota: 1,
     fingerprint: "unique-fingerprint",

--- a/src/Components/RemoveConfirmationModal.test.tsx
+++ b/src/Components/RemoveConfirmationModal.test.tsx
@@ -95,4 +95,21 @@ describe("RemoveConfirmationModal", () => {
     fireEvent.click(getByText("Cancel"));
     expect(mockOnCancel).toHaveBeenCalled();
   });
+
+  it("should display an error message if errorMessage is provided", () => {
+    const { getByTestId } = render(
+      <RemoveConfirmationModal
+        name="test-bucket"
+        onRemove={mockOnRemove}
+        onCancel={mockOnCancel}
+        resourceType="bucket"
+        open={true}
+        errorMessage="An error occurred"
+      />,
+    );
+
+    const alert = getByTestId("error-alert");
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent("An error occurred");
+  });
 });

--- a/src/Components/RemoveConfirmationModal.test.tsx
+++ b/src/Components/RemoveConfirmationModal.test.tsx
@@ -19,7 +19,7 @@ describe("RemoveConfirmationModal", () => {
         onRemove={mockOnRemove}
         onCancel={mockOnCancel}
         resourceType="bucket"
-        confirm={true}
+        open={true}
       />,
     );
     expect(getByText('Remove bucket "test-bucket"?')).toBeInTheDocument();
@@ -32,7 +32,7 @@ describe("RemoveConfirmationModal", () => {
         onRemove={mockOnRemove}
         onCancel={mockOnCancel}
         resourceType="bucket"
-        confirm={true}
+        open={true}
       />,
     );
 
@@ -51,7 +51,7 @@ describe("RemoveConfirmationModal", () => {
         onRemove={mockOnRemove}
         onCancel={mockOnCancel}
         resourceType="bucket"
-        confirm={true}
+        open={true}
       />,
     );
 
@@ -70,7 +70,7 @@ describe("RemoveConfirmationModal", () => {
         onRemove={mockOnRemove}
         onCancel={mockOnCancel}
         resourceType="bucket"
-        confirm={true}
+        open={true}
       />,
     );
 
@@ -88,7 +88,7 @@ describe("RemoveConfirmationModal", () => {
         onRemove={mockOnRemove}
         onCancel={mockOnCancel}
         resourceType="bucket"
-        confirm={true}
+        open={true}
       />,
     );
 

--- a/src/Components/RemoveConfirmationModal.tsx
+++ b/src/Components/RemoveConfirmationModal.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect, useState } from "react";
-import { Form, Input, Modal } from "antd";
+import React, { useState } from "react";
+import { Alert, Flex, Form, Input, Modal } from "antd";
 
 interface RemoveConfirmationModalProps {
   name: string;
   onRemove: () => void;
   onCancel: () => void;
   resourceType: string;
-  confirm: boolean;
+  open: boolean;
+  errorMessage?: string | null;
 }
 
 export default function RemoveConfirmationModal({
@@ -14,14 +15,10 @@ export default function RemoveConfirmationModal({
   onRemove,
   onCancel,
   resourceType,
-  confirm,
+  open,
+  errorMessage,
 }: RemoveConfirmationModalProps) {
-  const [confirmRemove, setConfirmRemove] = useState(false);
   const [confirmName, setConfirmName] = useState(false);
-
-  useEffect(() => {
-    setConfirmRemove(confirm);
-  }, [confirm]);
 
   const checkName = (bucketName: string) => {
     setConfirmName(bucketName == name);
@@ -29,10 +26,9 @@ export default function RemoveConfirmationModal({
 
   return (
     <Modal
-      open={confirmRemove}
+      open={open}
       onOk={() => {
         onRemove();
-        setConfirmRemove(false);
       }}
       onCancel={onCancel}
       closable={false}
@@ -42,15 +38,25 @@ export default function RemoveConfirmationModal({
       okType="danger"
       data-testid="delete-modal"
     >
-      <p>
-        For confirmation type <b>{name}</b>
-      </p>
-      <Form.Item name="confirm">
-        <Input
-          onChange={(e) => checkName(e.target.value)}
-          data-testid="confirm-input"
-        ></Input>
-      </Form.Item>
+      <Flex vertical gap="small">
+        <p>
+          For confirmation type <b>{name}</b>
+        </p>
+        {errorMessage && (
+          <Alert
+            message={errorMessage}
+            type="error"
+            showIcon
+            data-testid="error-alert"
+          />
+        )}
+        <Form.Item name="confirm">
+          <Input
+            onChange={(e) => checkName(e.target.value)}
+            data-testid="confirm-input"
+          />
+        </Form.Item>
+      </Flex>
     </Modal>
   );
 }

--- a/src/Components/RemoveConfirmationModal.tsx
+++ b/src/Components/RemoveConfirmationModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Alert, Flex, Form, Input, Modal } from "antd";
+import { Alert, Flex, Input, Modal } from "antd";
 
 interface RemoveConfirmationModalProps {
   name: string;
@@ -39,9 +39,6 @@ export default function RemoveConfirmationModal({
       data-testid="delete-modal"
     >
       <Flex vertical gap="small">
-        <p>
-          For confirmation type <b>{name}</b>
-        </p>
         {errorMessage && (
           <Alert
             message={errorMessage}
@@ -50,12 +47,11 @@ export default function RemoveConfirmationModal({
             data-testid="error-alert"
           />
         )}
-        <Form.Item name="confirm">
-          <Input
-            onChange={(e) => checkName(e.target.value)}
-            data-testid="confirm-input"
-          />
-        </Form.Item>
+        <Input
+          placeholder={`Type the name of the ${resourceType} to confirm`}
+          onChange={(e) => checkName(e.target.value)}
+          data-testid="confirm-input"
+        />
       </Flex>
     </Modal>
   );

--- a/src/Components/Replication/ReplicationCard.tsx
+++ b/src/Components/Replication/ReplicationCard.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
 import { Card, Col, Modal, Row, Statistic, Tag } from "antd";
-import { Client, FullReplicationInfo, TokenPermissions } from "reduct-js";
+import {
+  APIError,
+  Client,
+  FullReplicationInfo,
+  TokenPermissions,
+} from "reduct-js";
 import { DeleteOutlined, SettingOutlined } from "@ant-design/icons";
 
 import "./ReplicationCard.css";
@@ -20,14 +25,21 @@ interface Props {
 }
 
 export default function ReplicationCard(props: Readonly<Props>) {
-  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [isRemoveModalOpen, setIsRemoveModalOpen] = useState(false);
   const [changeSettings, setChangeSettings] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
   const { client, replication, index } = props;
   const { info, diagnostics } = replication;
 
   const onRemove = async () => {
-    await client.deleteReplication(info.name);
-    props.onRemove(info.name);
+    try {
+      await client.deleteReplication(info.name);
+      props.onRemove(info.name);
+    } catch (err) {
+      console.error(err);
+      if (err instanceof APIError && err.message) setRemoveError(err.message);
+      else setRemoveError("Failed to remove replication.");
+    }
   };
 
   const actions = [];
@@ -47,7 +59,7 @@ export default function ReplicationCard(props: Readonly<Props>) {
           title="Remove"
           key="delete"
           style={{ color: "red" }}
-          onClick={() => setConfirmRemove(true)}
+          onClick={() => setIsRemoveModalOpen(true)}
         />,
       );
     }
@@ -90,9 +102,13 @@ export default function ReplicationCard(props: Readonly<Props>) {
       <RemoveConfirmationModal
         name={info.name}
         onRemove={onRemove}
-        onCancel={() => setConfirmRemove(false)}
-        confirm={confirmRemove}
-        resourceType="bucket"
+        onCancel={() => {
+          setIsRemoveModalOpen(false);
+          setRemoveError(null);
+        }}
+        open={isRemoveModalOpen}
+        resourceType="replication"
+        errorMessage={removeError}
       />
       <Modal
         title="Settings"

--- a/src/Components/Replication/ReplicationCard.tsx
+++ b/src/Components/Replication/ReplicationCard.tsx
@@ -35,6 +35,8 @@ export default function ReplicationCard(props: Readonly<Props>) {
     try {
       await client.deleteReplication(info.name);
       props.onRemove(info.name);
+      setRemoveError(null);
+      setIsRemoveModalOpen(false);
     } catch (err) {
       console.error(err);
       if (err instanceof APIError && err.message) setRemoveError(err.message);

--- a/src/Views/BucketPanel/BucketDetail.tsx
+++ b/src/Views/BucketPanel/BucketDetail.tsx
@@ -85,16 +85,13 @@ export default function BucketDetail(props: Readonly<Props>) {
     }
 
     try {
-      // test throw error here
-      throw new Error("test error");
-
-      // const { client } = props;
-      // const bucket: Bucket = await client.getBucket(info.name);
-      // await bucket.removeEntry(name);
-      // setEntryToRemove("");
-      // getEntries().then();
-      // setRemoveError(null);
-      // setIsRemoveModalOpen(false);
+      const { client } = props;
+      const bucket: Bucket = await client.getBucket(info.name);
+      await bucket.removeEntry(name);
+      setEntryToRemove("");
+      getEntries().then();
+      setRemoveError(null);
+      setIsRemoveModalOpen(false);
     } catch (err) {
       console.error(err);
       if (err instanceof APIError && err.message) setRemoveError(err.message);

--- a/src/Views/BucketPanel/BucketDetail.tsx
+++ b/src/Views/BucketPanel/BucketDetail.tsx
@@ -29,7 +29,9 @@ export default function BucketDetail(props: Readonly<Props>) {
   const [entries, setEntries] = useState<EntryInfo[]>([]);
   const [entryToRemove, setEntryToRemove] = useState<string>("");
   const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
+  const [isRemoveModalOpen, setIsRemoveModalOpen] = useState(false);
   const [entryToRename, setEntryToRename] = useState<string>("");
+  const [removeError, setRemoveError] = useState<string | null>(null);
   const [renameError, setRenameError] = useState<string | null>(null);
 
   const getEntries = async () => {
@@ -78,15 +80,31 @@ export default function BucketDetail(props: Readonly<Props>) {
 
   const removeEntry = async (name: string) => {
     if (!info) {
-      console.error("No bucket info");
+      setRemoveError("No bucket info");
       return;
     }
 
-    const { client } = props;
-    const bucket: Bucket = await client.getBucket(info.name);
-    await bucket.removeEntry(name);
-    setEntryToRemove("");
-    getEntries().then();
+    try {
+      // test throw error here
+      throw new Error("test error");
+
+      // const { client } = props;
+      // const bucket: Bucket = await client.getBucket(info.name);
+      // await bucket.removeEntry(name);
+      // setEntryToRemove("");
+      // getEntries().then();
+      // setRemoveError(null);
+      // setIsRemoveModalOpen(false);
+    } catch (err) {
+      console.error(err);
+      if (err instanceof APIError && err.message) setRemoveError(err.message);
+      else setRemoveError("Failed to remove entry.");
+    }
+  };
+
+  const handleOpenRemoveModal = (entryName: string) => {
+    setEntryToRemove(entryName);
+    setIsRemoveModalOpen(true);
   };
 
   useEffect(() => {
@@ -151,7 +169,7 @@ export default function BucketDetail(props: Readonly<Props>) {
                 key={entry.name}
                 style={{ color: "red" }}
                 title="Remove entry"
-                onClick={() => setEntryToRemove(entry.name)}
+                onClick={() => handleOpenRemoveModal(entry.name)}
               />
             </Flex>
           );
@@ -187,9 +205,13 @@ export default function BucketDetail(props: Readonly<Props>) {
         key={entryToRemove}
         name={entryToRemove}
         onRemove={() => removeEntry(entryToRemove)}
-        onCancel={() => setEntryToRemove("")}
+        onCancel={() => {
+          setRemoveError(null);
+          setIsRemoveModalOpen(false);
+        }}
         resourceType="entry"
-        confirm={entryToRemove !== ""}
+        open={isRemoveModalOpen}
+        errorMessage={removeError}
       />
       <RenameModal
         name={entryToRename}

--- a/src/Views/BucketPanel/BucketList.tsx
+++ b/src/Views/BucketPanel/BucketList.tsx
@@ -45,6 +45,7 @@ export default function BucketList(props: Readonly<Props>) {
       const bucket = await client.getBucket(name);
       await bucket.remove();
       setBuckets(buckets.filter((bucket) => bucket.name !== name));
+      setConfirmRemove(false);
     } catch (err) {
       console.error(err);
     }

--- a/src/Views/BucketPanel/BucketList.tsx
+++ b/src/Views/BucketPanel/BucketList.tsx
@@ -45,7 +45,6 @@ export default function BucketList(props: Readonly<Props>) {
       const bucket = await client.getBucket(name);
       await bucket.remove();
       setBuckets(buckets.filter((bucket) => bucket.name !== name));
-      setConfirmRemove(false);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
Closes #73  

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Fix state to ensure that the delete modal can reopen after removing a first bucket

### Related issues

#73 

### Does this PR introduce a breaking change?

No

### Other information:
