### PR TITLE
RS-658: fix server-side channel error for empty conditional query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-658: fix server-side channel error for empty conditional query, [PR-88](https://github.com/reductstore/web-console/pull/88)
+
 ### [1.9.0] - 2025-02-25
 
 ### Fixed

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -144,6 +144,13 @@ describe("EntryDetail", () => {
     expect(rows.at(1).text()).toContain("2.0 KB");
     expect(rows.at(1).text()).toContain("text/plain");
     expect(rows.at(1).text()).toContain('"type": "test"');
+
+    expect(bucket.query).toBeCalledWith("testEntry", undefined, undefined, {
+      head: true,
+      limit: 10,
+      strict: true,
+      when: {},
+    });
   });
 
   it("should toggle between ISO and Unix timestamps", async () => {

--- a/src/Views/BucketPanel/EntryDetail.tsx
+++ b/src/Views/BucketPanel/EntryDetail.tsx
@@ -51,13 +51,20 @@ export default function EntryDetail(props: Readonly<Props>) {
     setIsLoading(true);
     setRecords([]);
     setWhenError("");
+
     try {
       const bucket = await props.client.getBucket(bucketName);
+
       const options = new QueryOptions();
       options.limit = limit;
       options.head = true;
       options.strict = true;
-      if (whenCondition.trim()) options.when = JSON.parse(whenCondition);
+      if (whenCondition.trim().length > 0) {
+        options.when = JSON.parse(whenCondition);
+      } else {
+        options.when = {}; // enable POST endpoint that handle the head flag correctly
+      }
+
       for await (const record of bucket.query(entryName, start, end, options)) {
         setRecords((records) => [...records, record]);
       }
@@ -234,6 +241,9 @@ export default function EntryDetail(props: Readonly<Props>) {
               matchBrackets: true,
               autoCloseBrackets: true,
             }}
+            onChange={(editor, data, value) => {
+              setWhenCondition(formatJSON(value));
+            }}
             onBeforeChange={(editor, data, value) => {
               setWhenCondition(value);
             }}
@@ -255,7 +265,11 @@ export default function EntryDetail(props: Readonly<Props>) {
           </Typography.Text>
         </div>
         <div className="fetchButton">
-          <Button onClick={handleFetchRecordsClick} type="primary">
+          <Button
+            onClick={handleFetchRecordsClick}
+            type="primary"
+            id="fetchButton"
+          >
             Fetch Records
           </Button>
         </div>

--- a/src/Views/BucketPanel/EntryDetail.tsx
+++ b/src/Views/BucketPanel/EntryDetail.tsx
@@ -26,6 +26,7 @@ import "codemirror/mode/javascript/javascript";
 
 // @ts-ignore
 import prettierBytes from "prettier-bytes";
+
 interface Props {
   client: Client;
   permissions?: TokenPermissions;
@@ -241,9 +242,6 @@ export default function EntryDetail(props: Readonly<Props>) {
               matchBrackets: true,
               autoCloseBrackets: true,
             }}
-            onChange={(editor, data, value) => {
-              setWhenCondition(formatJSON(value));
-            }}
             onBeforeChange={(editor, data, value) => {
               setWhenCondition(value);
             }}
@@ -265,11 +263,7 @@ export default function EntryDetail(props: Readonly<Props>) {
           </Typography.Text>
         </div>
         <div className="fetchButton">
-          <Button
-            onClick={handleFetchRecordsClick}
-            type="primary"
-            id="fetchButton"
-          >
+          <Button onClick={handleFetchRecordsClick} type="primary">
             Fetch Records
           </Button>
         </div>

--- a/src/Views/BucketPanel/EntryDetail.tsx
+++ b/src/Views/BucketPanel/EntryDetail.tsx
@@ -63,7 +63,7 @@ export default function EntryDetail(props: Readonly<Props>) {
       if (whenCondition.trim().length > 0) {
         options.when = JSON.parse(whenCondition);
       } else {
-        options.when = {}; // enable POST endpoint that handle the head flag correctly
+        options.when = {}; // enable POST endpoint that handles the head flag correctly
       }
 
       for await (const record of bucket.query(entryName, start, end, options)) {


### PR DESCRIPTION
Closes #87 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PRs initialise the `when' option in the query request, even if a use doesn't set the conditional query. This forces the SDK to correctly use the POST endpoint, which supports fetching records without content.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
