### PR TITLE
RS-613: Add record label editing functionality with modal dialog and JSON editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
-- RS-xyz: Add record label editing functionality, [PR-xx](https://github.com/reductstore/web-console/pull/xx)
+- RS-613: Add record label editing functionality, [PR-93](https://github.com/reductstore/web-console/pull/93)
 - RS-605: Add when conditions to replication settings in WebConsole, [PR-89](https://github.com/reductstore/web-console/pull/89)
 - RS-587: File upload dialog in EntryDetail view allowing users to upload files with metadata, [PR-82](https://github.com/reductstore/web-console/pull/82)
 - RS-632: Add upload button to bucket panel allowing users to create new entries by uploading files, [PR-86](https://github.com/reductstore/web-console/pull/86)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
+- RS-xyz: Add record label editing functionality, [PR-xx](https://github.com/reductstore/web-console/pull/xx)
 - RS-605: Add when conditions to replication settings in WebConsole, [PR-89](https://github.com/reductstore/web-console/pull/89)
 - RS-587: File upload dialog in EntryDetail view allowing users to upload files with metadata, [PR-82](https://github.com/reductstore/web-console/pull/82)
 - RS-632: Add upload button to bucket panel allowing users to create new entries by uploading files, [PR-86](https://github.com/reductstore/web-console/pull/86)

--- a/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.css
+++ b/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.css
@@ -11,26 +11,89 @@
   margin-bottom: 8px;
 }
 
-.edit-record-labels-modal .json-editor-container {
+.edit-record-labels-modal .label-table-container {
   margin-bottom: 16px;
-}
-
-.edit-record-labels-modal .jsonEditor {
-  border: 1px solid #d9d9d9;
-  border-radius: 2px;
-  font-family: monospace;
-}
-
-/* Fix CodeMirror styling */
-.edit-record-labels-modal .CodeMirror {
-  height: auto;
-  min-height: 100px;
-}
-
-.edit-record-labels-modal .CodeMirror-scroll {
-  min-height: 100px;
 }
 
 .edit-record-labels-modal .error-message {
   margin-top: 16px;
+}
+
+/* Editable table styles */
+.edit-record-labels-modal .editable-cell {
+  position: relative;
+}
+
+.edit-record-labels-modal .editable-cell-value-wrap {
+  padding: 5px 12px;
+  cursor: pointer;
+}
+
+/* Remove hover border effect */
+.edit-record-labels-modal .editable-row:hover .editable-cell-value-wrap {
+  padding: 5px 12px;
+  /* No border on hover */
+}
+
+/* Style validation errors */
+.edit-record-labels-modal .ant-form-item {
+  margin-bottom: 0;
+}
+
+/* Error message styling */
+.edit-record-labels-modal .ant-form-item-explain {
+  color: #ff4d4f;
+  font-size: 12px;
+  padding: 4px 0;
+  line-height: 1.2;
+  position: absolute;
+  margin-top: 4px;
+}
+
+/* Ensure table cells have enough space and centered content */
+.edit-record-labels-modal .ant-table-cell {
+  padding: 12px;
+  vertical-align: middle;
+}
+
+/* Add spacing between rows */
+.edit-record-labels-modal .ant-table-tbody > tr {
+  margin-bottom: 20px;
+}
+
+.edit-record-labels-modal .ant-table-tbody > tr > td {
+  border-bottom: 1px solid #f0f0f0;
+}
+
+/* Style the input fields */
+.edit-record-labels-modal .ant-input {
+  height: 32px;
+}
+
+/* Style the editable cell value wrap */
+.edit-record-labels-modal .editable-cell-value-wrap {
+  width: 100%;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+}
+
+/* Style the placeholder text */
+.edit-record-labels-modal .placeholder-text {
+  color: #bfbfbf;
+}
+
+/* Style the add label button */
+.edit-record-labels-modal .add-label-button {
+  margin-bottom: 16px;
+}
+
+/* Style the form item */
+.edit-record-labels-modal .edit-form-item {
+  margin: 0;
+}
+
+/* Style the input field */
+.edit-record-labels-modal .edit-input {
+  width: 100%;
 }

--- a/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.css
+++ b/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.css
@@ -1,0 +1,36 @@
+.edit-record-labels-modal .record-info {
+  margin-bottom: 16px;
+}
+
+.edit-record-labels-modal .record-info-label {
+  font-weight: bold;
+}
+
+.edit-record-labels-modal .help-text {
+  font-size: 0.85em;
+  margin-bottom: 8px;
+}
+
+.edit-record-labels-modal .json-editor-container {
+  margin-bottom: 16px;
+}
+
+.edit-record-labels-modal .jsonEditor {
+  border: 1px solid #d9d9d9;
+  border-radius: 2px;
+  font-family: monospace;
+}
+
+/* Fix CodeMirror styling */
+.edit-record-labels-modal .CodeMirror {
+  height: auto;
+  min-height: 100px;
+}
+
+.edit-record-labels-modal .CodeMirror-scroll {
+  min-height: 100px;
+}
+
+.edit-record-labels-modal .error-message {
+  margin-top: 16px;
+}

--- a/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.tsx
+++ b/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.tsx
@@ -1,10 +1,6 @@
-import React, { useState, useEffect } from "react";
-import { Modal, Typography, Alert } from "antd";
-import { Controlled as CodeMirror } from "react-codemirror2";
-import "codemirror/lib/codemirror.css";
-import "codemirror/mode/javascript/javascript";
-import "codemirror/addon/edit/matchbrackets";
-import "codemirror/addon/edit/closebrackets";
+import React, { useState, useEffect, createContext, useContext } from "react";
+import { Modal, Typography, Alert, Table, Input, Button, Form } from "antd";
+import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
 import "./EditRecordLabelsModal.css";
 import { APIError } from "reduct-js";
 
@@ -19,6 +15,96 @@ interface EditRecordLabelsModalProps {
   onLabelsUpdated: () => void;
 }
 
+const EditableContext = createContext<any>(null);
+
+const EditableRow: React.FC<any> = ({ index, ...props }) => {
+  const [form] = Form.useForm();
+  return (
+    <Form form={form} component={false}>
+      <EditableContext.Provider value={form}>
+        <tr {...props} />
+      </EditableContext.Provider>
+    </Form>
+  );
+};
+
+const EditableCell: React.FC<any> = ({
+  title,
+  editable,
+  children,
+  dataIndex,
+  record,
+  handleSave,
+  ...restProps
+}) => {
+  const [editing, setEditing] = useState(false);
+  const inputRef = React.useRef<any>(null);
+  const form = useContext(EditableContext);
+
+  useEffect(() => {
+    if (editing) {
+      form.setFieldsValue({ [dataIndex]: record[dataIndex] });
+      inputRef.current?.focus();
+    }
+  }, [editing, form, dataIndex, record]);
+
+  const toggleEdit = () => {
+    setEditing(!editing);
+  };
+
+  const save = async () => {
+    try {
+      const values = await form.validateFields();
+      toggleEdit();
+      handleSave({ ...record, [dataIndex]: values[dataIndex] });
+    } catch (errInfo) {
+      console.log("Save failed:", errInfo);
+    }
+  };
+
+  let childNode = children;
+
+  if (editable) {
+    childNode = editing ? (
+      <Form.Item
+        className="edit-form-item"
+        name={dataIndex}
+        rules={[
+          {
+            required: true,
+            message: `${title} is required.`,
+          },
+        ]}
+      >
+        <Input
+          ref={inputRef}
+          onPressEnter={save}
+          onBlur={save}
+          placeholder={dataIndex === "key" ? "Enter key" : "Enter value"}
+          className="edit-input"
+        />
+      </Form.Item>
+    ) : (
+      <div className="editable-cell-value-wrap" onClick={toggleEdit}>
+        {children || (
+          <span className="placeholder-text">
+            {dataIndex === "key" ? "Enter key" : "Enter value"}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return <td {...restProps}>{childNode}</td>;
+};
+
+interface LabelItem {
+  id: string;
+  key: string;
+  value: string;
+  originalKey?: string;
+}
+
 const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
   isVisible,
   onCancel,
@@ -29,7 +115,7 @@ const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
   showUnix,
   onLabelsUpdated,
 }) => {
-  const [labelsJson, setLabelsJson] = useState<string | null>();
+  const [labelItems, setLabelItems] = useState<LabelItem[]>([]);
   const [labelUpdateError, setLabelUpdateError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -37,40 +123,166 @@ const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
     setLabelUpdateError(null);
     try {
       const labels = record.labels || {};
-
       const labelsObj =
         typeof labels === "string" ? JSON.parse(labels) : labels;
 
-      const formattedLabels = JSON.stringify(labelsObj, null, 2);
-      setLabelsJson(formattedLabels);
+      const items = Object.entries(labelsObj).map(([key, value], index) => ({
+        id: `label-${index}`,
+        key,
+        value: String(value),
+        originalKey: key,
+      }));
+
+      setLabelItems(items);
     } catch (error) {
       console.error("Error preparing labels for display:", error);
-      setLabelsJson("{}");
+      setLabelItems([]);
     }
   }, [record]);
 
   const handleUpdateLabels = async () => {
-    if (!record || !labelsJson) return;
+    if (!record) return;
     setLabelUpdateError(null);
     try {
-      const labels = JSON.parse(labelsJson);
+      const keySet = new Set<string>();
+      const duplicateKeys: string[] = [];
+
+      labelItems.forEach((item) => {
+        if (item.key && keySet.has(item.key)) {
+          duplicateKeys.push(item.key);
+        } else if (item.key) {
+          keySet.add(item.key);
+        }
+      });
+
+      if (duplicateKeys.length > 0) {
+        setLabelUpdateError(
+          `Duplicate keys found: ${duplicateKeys.join(", ")}. Please ensure all keys are unique.`,
+        );
+        return;
+      }
+
+      const originalLabels = record.labels || {};
+      const originalLabelsObj =
+        typeof originalLabels === "string"
+          ? JSON.parse(originalLabels)
+          : originalLabels;
+
+      const newLabels: Record<string, string> = {};
+
+      labelItems.forEach((item) => {
+        if (item.key.trim()) {
+          newLabels[item.key] = item.value;
+        }
+      });
+
+      const keysToRemove = new Set<string>();
+      Object.keys(originalLabelsObj).forEach((originalKey) => {
+        if (!Object.keys(newLabels).includes(originalKey)) {
+          keysToRemove.add(originalKey);
+        }
+      });
+
+      keysToRemove.forEach((key) => {
+        newLabels[key] = "";
+      });
+
       const { timestamp } = record;
 
       const bucket = await client.getBucket(bucketName);
-      await bucket.update(entryName, timestamp, labels);
+      await bucket.update(entryName, timestamp, newLabels);
 
       onLabelsUpdated();
       onCancel();
     } catch (err) {
-      if (err instanceof SyntaxError)
-        setLabelUpdateError("Invalid JSON format: " + err.message);
-      else if (err instanceof APIError)
+      if (err instanceof APIError)
         setLabelUpdateError(err.message || "API Error");
       else if (err instanceof Error)
         setLabelUpdateError(err.message || "Failed to update labels.");
       else setLabelUpdateError("Failed to update labels: " + String(err));
     }
   };
+
+  const handleSave = (row: LabelItem) => {
+    const newData = [...labelItems];
+    const index = newData.findIndex((item) => item.id === row.id);
+
+    if (index > -1) {
+      const updatedItem = {
+        ...newData[index],
+        ...row,
+      };
+
+      newData.splice(index, 1, updatedItem);
+      setLabelItems(newData);
+    }
+  };
+
+  const handleDelete = (id: string) => {
+    setLabelItems(labelItems.filter((item) => item.id !== id));
+  };
+
+  const handleAdd = () => {
+    const newId = `label-${Date.now()}`;
+    const newItem: LabelItem = {
+      id: newId,
+      key: "",
+      value: "",
+      originalKey: undefined,
+    };
+
+    setLabelItems([...labelItems, newItem]);
+  };
+
+  const columns = [
+    {
+      title: "Key",
+      dataIndex: "key",
+      width: "40%",
+      editable: true,
+    },
+    {
+      title: "Value",
+      dataIndex: "value",
+      width: "40%",
+      editable: true,
+    },
+    {
+      title: "Action",
+      dataIndex: "operation",
+      render: (_: any, record: LabelItem) => (
+        <Button
+          type="text"
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => handleDelete(record.id)}
+        />
+      ),
+    },
+  ];
+
+  const components = {
+    body: {
+      row: EditableRow,
+      cell: EditableCell,
+    },
+  };
+
+  const columnsWithEditable = columns.map((col) => {
+    if (!col.editable) {
+      return col;
+    }
+    return {
+      ...col,
+      onCell: (record: LabelItem) => ({
+        record,
+        editable: col.editable,
+        dataIndex: col.dataIndex,
+        title: col.title,
+        handleSave,
+      }),
+    };
+  });
 
   return (
     <Modal
@@ -106,47 +318,30 @@ const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
             </Typography.Text>
             <Typography.Text>{record.size}</Typography.Text>
           </div>
-          <Typography.Text>Edit Labels (JSON format):</Typography.Text>
+          <Typography.Text>Edit Labels:</Typography.Text>
           <div className="help-text">
             <Typography.Text type="secondary">
-              Note: To remove a label, remove the key-value pair from the JSON
+              Note: To remove a label, click the delete button
             </Typography.Text>
           </div>
-          <div className="json-editor-container">
-            {labelsJson && (
-              <CodeMirror
-                className="jsonEditor"
-                value={labelsJson}
-                options={{
-                  mode: { name: "javascript", json: true },
-                  theme: "default",
-                  lineNumbers: true,
-                  lineWrapping: true,
-                  viewportMargin: Infinity,
-                  matchBrackets: true,
-                  autoCloseBrackets: true,
-                  firstLineNumber: 1,
-                  indentWithTabs: false,
-                  indentUnit: 2,
-                  tabSize: 2,
-                }}
-                onBeforeChange={(editor: any, data: any, value: string) => {
-                  setLabelsJson(value);
-                }}
-                onBlur={(editor: any) => {
-                  const value = editor.getValue() || "";
-                  try {
-                    // Parse and reformat to ensure proper structure
-                    const parsed = JSON.parse(value);
-                    const formatted = JSON.stringify(parsed, null, 2);
-                    setLabelsJson(formatted);
-                  } catch (e) {
-                    // Keep the value as is if it's not valid JSON
-                    console.error("Error formatting JSON on blur:", e);
-                  }
-                }}
-              />
-            )}
+          <div className="label-table-container">
+            <Button
+              type="primary"
+              onClick={handleAdd}
+              className="add-label-button"
+              icon={<PlusOutlined />}
+            >
+              Add Label
+            </Button>
+            <Table
+              components={components}
+              rowClassName="editable-row"
+              bordered
+              dataSource={labelItems}
+              columns={columnsWithEditable}
+              pagination={false}
+              rowKey="id"
+            />
           </div>
           {labelUpdateError && (
             <Alert

--- a/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.tsx
+++ b/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.tsx
@@ -286,7 +286,7 @@ const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
 
   return (
     <Modal
-      title="Edit Record Labels"
+      title="Labels"
       open={isVisible}
       onCancel={onCancel}
       onOk={handleUpdateLabels}
@@ -318,7 +318,7 @@ const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
             </Typography.Text>
             <Typography.Text>{record.size}</Typography.Text>
           </div>
-          <Typography.Text>Edit Labels:</Typography.Text>
+          <Typography.Text>Labels:</Typography.Text>
           <div className="help-text">
             <Typography.Text type="secondary">
               Note: To remove a label, click the delete button
@@ -326,13 +326,12 @@ const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
           </div>
           <div className="label-table-container">
             <Button
-              type="primary"
+              style={{ float: "right" }}
               onClick={handleAdd}
               className="add-label-button"
               icon={<PlusOutlined />}
-            >
-              Add Label
-            </Button>
+              title="Add"
+            />
             <Table
               components={components}
               rowClassName="editable-row"

--- a/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.tsx
+++ b/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.tsx
@@ -286,7 +286,6 @@ const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
 
   return (
     <Modal
-      title="Labels"
       open={isVisible}
       onCancel={onCancel}
       onOk={handleUpdateLabels}
@@ -298,7 +297,7 @@ const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
         <>
           <div className="record-info">
             <Typography.Text className="record-info-label">
-              Record Timestamp:{" "}
+              Timestamp:{" "}
             </Typography.Text>
             <Typography.Text>
               {showUnix
@@ -318,12 +317,9 @@ const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
             </Typography.Text>
             <Typography.Text>{record.size}</Typography.Text>
           </div>
-          <Typography.Text>Labels:</Typography.Text>
-          <div className="help-text">
-            <Typography.Text type="secondary">
-              Note: To remove a label, click the delete button
-            </Typography.Text>
-          </div>
+          <Typography.Text className="record-info-label">
+            Labels:
+          </Typography.Text>
           <div className="label-table-container">
             <Button
               style={{ float: "right" }}

--- a/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.tsx
+++ b/src/Components/EditRecordLabelsModal/EditRecordLabelsModal.tsx
@@ -1,0 +1,192 @@
+import React, { useState, useEffect } from "react";
+import { Modal, Typography, Alert } from "antd";
+import { Controlled as CodeMirror } from "react-codemirror2";
+import "codemirror/lib/codemirror.css";
+import "codemirror/mode/javascript/javascript";
+import "codemirror/addon/edit/matchbrackets";
+import "codemirror/addon/edit/closebrackets";
+import "./EditRecordLabelsModal.css";
+import { APIError } from "reduct-js";
+
+interface EditRecordLabelsModalProps {
+  isVisible: boolean;
+  onCancel: () => void;
+  record: any;
+  client: any;
+  bucketName: string;
+  entryName: string;
+  showUnix: boolean;
+  onLabelsUpdated: () => void;
+}
+
+const EditRecordLabelsModal: React.FC<EditRecordLabelsModalProps> = ({
+  isVisible,
+  onCancel,
+  record,
+  client,
+  bucketName,
+  entryName,
+  showUnix,
+  onLabelsUpdated,
+}) => {
+  const [labelsJson, setLabelsJson] = useState<string>("{}");
+  const [labelUpdateError, setLabelUpdateError] = useState<string | null>(null);
+  const [editorKey, setEditorKey] = useState<number>(0);
+
+  // Prepare the initial JSON when the record changes
+  useEffect(() => {
+    if (record && isVisible) {
+      setLabelUpdateError(null);
+
+      try {
+        const labels = record.labels || {};
+
+        const labelsObj =
+          typeof labels === "string" ? JSON.parse(labels) : labels;
+
+        const formattedLabels = JSON.stringify(labelsObj, null, 2);
+        setLabelsJson(formattedLabels);
+
+        setEditorKey(Date.now());
+      } catch (error) {
+        console.error("Error preparing labels for display:", error);
+        setLabelsJson("{}");
+      }
+    }
+  }, [record, isVisible]);
+
+  // Force CodeMirror to refresh after the modal is fully visible
+  useEffect(() => {
+    if (isVisible) {
+      const timer1 = setTimeout(() => {
+        setEditorKey(Date.now());
+      }, 100);
+
+      const timer2 = setTimeout(() => {
+        setEditorKey(Date.now());
+      }, 300);
+
+      return () => {
+        clearTimeout(timer1);
+        clearTimeout(timer2);
+      };
+    }
+  }, [isVisible]);
+
+  const handleUpdateLabels = async () => {
+    if (!record) return;
+
+    setLabelUpdateError(null);
+
+    try {
+      const labels = JSON.parse(labelsJson);
+      const { timestamp } = record;
+
+      const bucket = await client.getBucket(bucketName);
+      await bucket.update(entryName, timestamp, labels);
+
+      onLabelsUpdated();
+      onCancel();
+    } catch (err) {
+      console.error(err);
+      if (err instanceof SyntaxError) {
+        setLabelUpdateError("Invalid JSON format: " + err.message);
+      } else if (err instanceof APIError) {
+        setLabelUpdateError(err.message || "API Error");
+      } else if (err instanceof Error) {
+        setLabelUpdateError(err.message || "Failed to update labels.");
+      } else {
+        setLabelUpdateError("Failed to update labels: " + String(err));
+      }
+    }
+  };
+
+  return (
+    <Modal
+      title="Edit Record Labels"
+      open={isVisible}
+      onCancel={onCancel}
+      onOk={handleUpdateLabels}
+      okText="Update Labels"
+      width={600}
+      className="edit-record-labels-modal"
+    >
+      {record && (
+        <>
+          <div className="record-info">
+            <Typography.Text className="record-info-label">
+              Record Timestamp:{" "}
+            </Typography.Text>
+            <Typography.Text>
+              {showUnix
+                ? record.key
+                : new Date(Number(record.timestamp / 1000n)).toISOString()}
+            </Typography.Text>
+          </div>
+          <div className="record-info">
+            <Typography.Text className="record-info-label">
+              Content Type:{" "}
+            </Typography.Text>
+            <Typography.Text>{record.contentType}</Typography.Text>
+          </div>
+          <div className="record-info">
+            <Typography.Text className="record-info-label">
+              Size:{" "}
+            </Typography.Text>
+            <Typography.Text>{record.size}</Typography.Text>
+          </div>
+          <Typography.Text>Edit Labels (JSON format):</Typography.Text>
+          <div className="help-text">
+            <Typography.Text type="secondary">
+              Note: To remove a label, remove the key-value pair from the JSON
+            </Typography.Text>
+          </div>
+          <div className="json-editor-container">
+            <CodeMirror
+              key={`editor-${editorKey}`}
+              className="jsonEditor"
+              value={labelsJson}
+              options={{
+                mode: { name: "javascript", json: true },
+                theme: "default",
+                lineNumbers: true,
+                lineWrapping: true,
+                viewportMargin: Infinity,
+                matchBrackets: true,
+                autoCloseBrackets: true,
+                firstLineNumber: 1,
+                indentWithTabs: false,
+                indentUnit: 2,
+                tabSize: 2,
+              }}
+              onBeforeChange={(editor: any, data: any, value: string) => {
+                setLabelsJson(value);
+              }}
+              onBlur={(editor: any) => {
+                const value = editor.getValue() || "";
+                try {
+                  // Parse and reformat to ensure proper structure
+                  const parsed = JSON.parse(value);
+                  const formatted = JSON.stringify(parsed, null, 2);
+                  setLabelsJson(formatted);
+                } catch (e) {
+                  // Keep the value as is if it's not valid JSON
+                  console.error("Error formatting JSON on blur:", e);
+                }
+              }}
+            />
+          </div>
+          {labelUpdateError && (
+            <Alert
+              type="error"
+              message={labelUpdateError}
+              className="error-message"
+            />
+          )}
+        </>
+      )}
+    </Modal>
+  );
+};
+
+export default EditRecordLabelsModal;

--- a/src/Components/EditRecordLabelsModal/index.ts
+++ b/src/Components/EditRecordLabelsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditRecordLabelsModal";

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -9,24 +9,6 @@ import { DownloadOutlined, EditOutlined } from "@ant-design/icons";
 import "codemirror/lib/codemirror.css";
 import "codemirror/mode/javascript/javascript";
 
-// Mock CodeMirror to prevent getBoundingClientRect errors in tests
-jest.mock("react-codemirror2", () => ({
-  Controlled: (props: any) => {
-    // Simple mock that just renders a div and calls onChange when needed
-    return (
-      <div
-        className="react-codemirror2 jsonEditor"
-        data-testid="codemirror-mock"
-      >
-        <textarea
-          value={props.value}
-          onChange={(e) => props.onBeforeChange?.(null, null, e.target.value)}
-        />
-      </div>
-    );
-  },
-}));
-
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useParams: () => ({
@@ -273,7 +255,7 @@ describe("EntryDetail", () => {
 
       const modal = wrapper.find(".ant-modal");
       expect(modal.exists()).toBe(true);
-      expect(modal.find(".ant-modal-title").text()).toBe("Edit Record Labels");
+      expect(modal.find(".ant-modal-title").text()).toBe("Labels");
 
       const modalContent = modal.find(".ant-modal-body").text();
       expect(modalContent).toContain("Record Timestamp");
@@ -297,9 +279,6 @@ describe("EntryDetail", () => {
       bucket.update = jest.fn().mockResolvedValue(undefined);
 
       (bucket.beginRead as jest.Mock).mockResolvedValue(mockReader);
-      (bucket.removeRecord as jest.Mock).mockResolvedValue(undefined);
-      (bucket.beginWrite as jest.Mock).mockResolvedValue(mockWriter);
-      mockWriter.write.mockResolvedValue(undefined);
 
       const recordRows = wrapper.find(".ant-table-row");
       expect(recordRows.length).toBeGreaterThan(0);

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -280,8 +280,9 @@ describe("EntryDetail", () => {
       expect(modalContent).toContain("Content Type");
       expect(modalContent).toContain("Size");
 
-      const jsonEditor = modal.find(".jsonEditor");
-      expect(jsonEditor.exists()).toBe(true);
+      // Check for the label table instead of CodeMirror
+      const labelTable = modal.find(".edit-record-labels-modal .ant-table");
+      expect(labelTable.exists()).toBe(true);
     });
 
     it("should verify record labels can be updated", async () => {

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -255,10 +255,9 @@ describe("EntryDetail", () => {
 
       const modal = wrapper.find(".ant-modal");
       expect(modal.exists()).toBe(true);
-      expect(modal.find(".ant-modal-title").text()).toBe("Labels");
 
       const modalContent = modal.find(".ant-modal-body").text();
-      expect(modalContent).toContain("Record Timestamp");
+      expect(modalContent).toContain("Timestamp");
       expect(modalContent).toContain("Content Type");
       expect(modalContent).toContain("Size");
 
@@ -283,12 +282,10 @@ describe("EntryDetail", () => {
       const recordRows = wrapper.find(".ant-table-row");
       expect(recordRows.length).toBeGreaterThan(0);
 
-      const firstRow = recordRows.at(0);
-
       const editIcon = wrapper.find(EditOutlined).at(0);
       expect(editIcon.exists()).toBe(true);
 
-      const onClick = editIcon.props().onClick;
+      const { onClick } = editIcon.props();
 
       act(() => {
         (onClick as any)(

--- a/src/Views/BucketPanel/EntryDetail.tsx
+++ b/src/Views/BucketPanel/EntryDetail.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from "react";
+// Add this to detect test environment
+const isTestEnv = process.env.NODE_ENV === "test";
 import { useHistory, useParams } from "react-router-dom";
 import {
   APIError,
@@ -18,7 +20,7 @@ import {
   Modal,
 } from "antd";
 import { ReadableRecord } from "reduct-js/lib/cjs/Record";
-import { DownloadOutlined } from "@ant-design/icons";
+import { DownloadOutlined, EditOutlined } from "@ant-design/icons";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import EntryCard from "../../Components/Entry/EntryCard";
 import "./EntryDetail.css";
@@ -56,6 +58,23 @@ export default function EntryDetail(props: Readonly<Props>) {
   const [whenCondition, setWhenCondition] = useState<string>("");
   const [whenError, setWhenError] = useState<string>("");
   const [isUploadModalVisible, setIsUploadModalVisible] = useState(false);
+  const [isEditLabelsModalVisible, setIsEditLabelsModalVisible] =
+    useState(false);
+  const [editorKey, setEditorKey] = useState(0);
+
+  // Force CodeMirror to refresh when modal becomes visible
+  useEffect(() => {
+    if (isEditLabelsModalVisible && !isTestEnv) {
+      // Need to wait for modal animation to complete
+      const timer = setTimeout(() => {
+        setEditorKey((prev) => prev + 1);
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isEditLabelsModalVisible]);
+  const [currentRecord, setCurrentRecord] = useState<any>(null);
+  const [labelsJson, setLabelsJson] = useState("");
+  const [labelUpdateError, setLabelUpdateError] = useState("");
   const [availableEntries, setAvailableEntries] = useState<string[]>([]);
 
   // Provide a default value for permissions
@@ -65,20 +84,13 @@ export default function EntryDetail(props: Readonly<Props>) {
     setIsLoading(true);
     setRecords([]);
     setWhenError("");
-
     try {
       const bucket = await props.client.getBucket(bucketName);
-
       const options = new QueryOptions();
       options.limit = limit;
       options.head = true;
       options.strict = true;
-      if (whenCondition.trim().length > 0) {
-        options.when = JSON.parse(whenCondition);
-      } else {
-        options.when = {}; // enable POST endpoint that handles the head flag correctly
-      }
-
+      if (whenCondition.trim()) options.when = JSON.parse(whenCondition);
       for await (const record of bucket.query(entryName, start, end, options)) {
         setRecords((records) => [...records, record]);
       }
@@ -114,6 +126,102 @@ export default function EntryDetail(props: Readonly<Props>) {
     }
   };
 
+  const handleEditLabels = (record: any) => {
+    setCurrentRecord(record);
+
+    // Format the labels exactly like the When Condition editor
+    let labelsJson = "{}";
+
+    if (record.labels) {
+      try {
+        // First convert to string if it's an object
+        const labelsStr =
+          typeof record.labels === "string"
+            ? record.labels
+            : JSON.stringify(record.labels);
+
+        // Parse and reformat to ensure proper structure
+        labelsJson = JSON.stringify(JSON.parse(labelsStr), null, 2);
+      } catch (error) {
+        console.error("Error formatting labels:", error);
+        labelsJson = "{}"; // Default to empty object if error
+      }
+    }
+
+    // Set it in the editor
+    setLabelsJson(labelsJson);
+    setLabelUpdateError("");
+    setIsEditLabelsModalVisible(true);
+  };
+
+  const handleUpdateLabels = async () => {
+    try {
+      // Parse the JSON to validate it
+      const labels = JSON.parse(labelsJson);
+      setLabelUpdateError("");
+
+      // Get the timestamp of the record to update
+      const timestamp = BigInt(currentRecord.key);
+
+      // Get the bucket
+      const bucket = await props.client.getBucket(bucketName);
+
+      try {
+        // First check if record exists and get its current information
+        const reader = await bucket.beginRead(entryName, timestamp, true); // true = head only (metadata)
+        const oldLabels = reader.labels;
+
+        // Add diagnostics info
+        console.log("Updating record labels for:", timestamp.toString());
+        console.log("Current labels:", oldLabels);
+        console.log("New labels:", labels);
+
+        // 1. Read the original record's full data
+        const fullReader = await bucket.beginRead(entryName, timestamp);
+        const recordData = await fullReader.read();
+        const recordContentType = fullReader.contentType;
+
+        // 2. Remove the old record
+        await bucket.removeRecord(entryName, timestamp);
+
+        // 3. Write a new record with the same timestamp but updated labels
+        const writer = await bucket.beginWrite(entryName, {
+          ts: timestamp,
+          contentType: recordContentType,
+          labels: labels,
+        });
+
+        // 4. Write the original data back
+        await writer.write(recordData);
+      } catch (error) {
+        let errorMessage = "Failed to update labels";
+
+        if (error instanceof APIError) {
+          errorMessage = error.message || errorMessage;
+        } else if (error instanceof Error) {
+          errorMessage = error.message;
+        }
+
+        throw new Error(errorMessage);
+      }
+
+      // Refresh the records to show updated labels
+      getRecords(start, end, limit);
+      setIsEditLabelsModalVisible(false);
+    } catch (err) {
+      console.error(err);
+      if (err instanceof SyntaxError) {
+        setLabelUpdateError("Invalid JSON format: " + err.message);
+      } else if (err instanceof APIError) {
+        setLabelUpdateError(err.message || "API Error");
+      } else if (err instanceof Error) {
+        setLabelUpdateError(err.message || "Failed to update labels.");
+      } else {
+        setLabelUpdateError("Failed to update labels: " + String(err));
+      }
+    }
+  };
+
   const handleDateChange = (dates: any) => {
     if (dates) {
       const startDate = dates[0].toDate();
@@ -146,6 +254,9 @@ export default function EntryDetail(props: Readonly<Props>) {
 
   useEffect(() => {
     getEntryInfo();
+  }, []);
+
+  useEffect(() => {
     getRecords(start, end, limit);
   }, [bucketName, entryName]);
 
@@ -164,12 +275,22 @@ export default function EntryDetail(props: Readonly<Props>) {
     { title: "Labels", dataIndex: "labels", key: "labels" },
     {
       title: "",
-      key: "download",
+      key: "actions",
       render: (text: any, record: any) => (
-        <DownloadOutlined
-          onClick={() => handleDownload(record)}
-          style={{ cursor: "pointer" }}
-        />
+        <div style={{ display: "flex", gap: "8px" }}>
+          <DownloadOutlined
+            onClick={() => handleDownload(record)}
+            style={{ cursor: "pointer" }}
+            title="Download record"
+          />
+          {hasWritePermission && (
+            <EditOutlined
+              onClick={() => handleEditLabels(record)}
+              style={{ cursor: "pointer" }}
+              title="Edit labels"
+            />
+          )}
+        </div>
       ),
     },
   ];
@@ -182,8 +303,12 @@ export default function EntryDetail(props: Readonly<Props>) {
     labels: JSON.stringify(record.labels, null, 2),
   }));
 
+  // Format JSON exactly like in the When Condition component
   const formatJSON = (jsonString: string): string => {
+    if (!jsonString) return "{}";
+
     try {
+      // Parse and re-stringify to ensure proper formatting
       return JSON.stringify(JSON.parse(jsonString), null, 2);
     } catch {
       return jsonString;
@@ -286,7 +411,8 @@ export default function EntryDetail(props: Readonly<Props>) {
               setWhenCondition(value);
             }}
             onBlur={(editor: any) => {
-              setWhenCondition(formatJSON(editor.getValue()));
+              const value = editor.getValue() || "";
+              setWhenCondition(formatJSON(value));
             }}
           />
           {whenError && <Alert type="error" message={whenError} />}
@@ -309,6 +435,75 @@ export default function EntryDetail(props: Readonly<Props>) {
         </div>
       </div>
       <Table columns={columns} dataSource={data} />
+
+      {/* Modal for editing labels */}
+      <Modal
+        title="Edit Record Labels"
+        open={isEditLabelsModalVisible}
+        onCancel={() => setIsEditLabelsModalVisible(false)}
+        onOk={handleUpdateLabels}
+        okText="Update Labels"
+        width={600}
+      >
+        {currentRecord && (
+          <>
+            <div style={{ marginBottom: 16 }}>
+              <Typography.Text strong>Record Timestamp: </Typography.Text>
+              <Typography.Text>
+                {showUnix
+                  ? currentRecord.key
+                  : new Date(
+                      Number(currentRecord.timestamp / 1000n),
+                    ).toISOString()}
+              </Typography.Text>
+            </div>
+            <div style={{ marginBottom: 16 }}>
+              <Typography.Text strong>Content Type: </Typography.Text>
+              <Typography.Text>{currentRecord.contentType}</Typography.Text>
+            </div>
+            <div style={{ marginBottom: 16 }}>
+              <Typography.Text strong>Size: </Typography.Text>
+              <Typography.Text>{currentRecord.size}</Typography.Text>
+            </div>
+            <Typography.Text>Edit Labels (JSON format):</Typography.Text>
+            <div style={{ marginBottom: 8 }}>
+              <Typography.Text type="secondary" style={{ fontSize: "0.85em" }}>
+                Note: To remove a label, remove the key-value pair from the JSON
+              </Typography.Text>
+            </div>
+            <div className="jsonFilterSection">
+              <CodeMirror
+                key={`editor-${editorKey}`}
+                className="jsonEditor"
+                value={labelsJson}
+                options={{
+                  mode: { name: "javascript", json: true },
+                  theme: "default",
+                  lineNumbers: true,
+                  lineWrapping: true,
+                  viewportMargin: Infinity,
+                  matchBrackets: true,
+                  autoCloseBrackets: true,
+                }}
+                onBeforeChange={(editor: any, data: any, value: string) => {
+                  setLabelsJson(value);
+                }}
+                onBlur={(editor: any) => {
+                  const value = editor.getValue() || "";
+                  setLabelsJson(formatJSON(value));
+                }}
+              />
+            </div>
+            {labelUpdateError && (
+              <Alert
+                type="error"
+                message={labelUpdateError}
+                style={{ marginTop: 16 }}
+              />
+            )}
+          </>
+        )}
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
Closes #90 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?
Feature: Add record label editing functionality with modal dialog and JSON editor

### What was changed?

Added edit icon for each record in the EntryDetail view
Implemented modal dialog showing record metadata (timestamp, content type, size)
Added CodeMirror-based JSON editor for modifying record labels
Implemented full update flow (read original → remove → write with new labels)
Added comprehensive tests for label editing functionality
Fixed how empty conditional queries are handled by setting an empty object ({}) instead of an empty string
Related issues
Feature implementation for record label editing Bug fix: RS-658 - Fix server-side channel error for empty conditional query

### Related issues

(Add links to related issues)

### Does this PR introduce a breaking change?

No, these are backward-compatible changes that enhance functionality without requiring changes from users.

### Other information:
