### PR TITLE
Remove limit field and use  JSON operator in query conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added:
 
+- Remove limit field and use $limit JSON operator in query conditions, [PR-101](https://github.com/reductstore/web-console/pull/101)
 - Add record deletion functionality, [PR-98](https://github.com/reductstore/web-console/pull/98)
 - RS-613: Add record label editing functionality, [PR-93](https://github.com/reductstore/web-console/pull/93)
 - RS-605: Add when conditions to replication settings in WebConsole, [PR-89](https://github.com/reductstore/web-console/pull/89)

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -204,16 +204,16 @@ describe("EntryDetail", () => {
       const exampleText = wrapper.find(".jsonExample").at(0).text();
       expect(exampleText).toContain("$limit");
     });
-    
+
     it("should call bucket.query with the correct when condition", async () => {
       const fetchButton = wrapper.find(".fetchButton button");
       expect(fetchButton.exists()).toBe(true);
-      
+
       await act(async () => {
-        fetchButton.simulate('click');
+        fetchButton.simulate("click");
         jest.runOnlyPendingTimers();
       });
-      
+
       expect(bucket.query).toHaveBeenCalledWith(
         "testEntry",
         undefined,
@@ -222,9 +222,9 @@ describe("EntryDetail", () => {
           head: true,
           strict: true,
           when: expect.objectContaining({
-            "$limit": 10
-          })
-        })
+            $limit: 10,
+          }),
+        }),
       );
     });
   });

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -204,6 +204,29 @@ describe("EntryDetail", () => {
       const exampleText = wrapper.find(".jsonExample").at(0).text();
       expect(exampleText).toContain("$limit");
     });
+    
+    it("should call bucket.query with the correct when condition", async () => {
+      const fetchButton = wrapper.find(".fetchButton button");
+      expect(fetchButton.exists()).toBe(true);
+      
+      await act(async () => {
+        fetchButton.simulate('click');
+        jest.runOnlyPendingTimers();
+      });
+      
+      expect(bucket.query).toHaveBeenCalledWith(
+        "testEntry",
+        undefined,
+        undefined,
+        expect.objectContaining({
+          head: true,
+          strict: true,
+          when: expect.objectContaining({
+            "$limit": 10
+          })
+        })
+      );
+    });
   });
 
   it("should fetch and display records", async () => {

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -18,6 +18,23 @@ type MockedRemoveRecord = RemoveRecordFn & {
   mockClear: () => void;
   mockRejectedValueOnce: (value: Error) => void;
 };
+
+jest.mock("react-codemirror2", () => ({
+  Controlled: (props: any) => {
+    return (
+      <div className="react-codemirror2" data-testid="codemirror-mock">
+        <textarea
+          value={props.value}
+          onChange={(e) => props.onBeforeChange(null, null, e.target.value)}
+          onBlur={(e) =>
+            props.onBlur && props.onBlur({ getValue: () => e.target.value })
+          }
+        />
+      </div>
+    );
+  },
+}));
+
 import "codemirror/lib/codemirror.css";
 import "codemirror/mode/javascript/javascript";
 
@@ -165,13 +182,12 @@ describe("EntryDetail", () => {
       expect(fetchButton.at(0).text()).toBe("Fetch Records");
     });
 
-    it("should show the records limit input", () => {
-      const limitInput = wrapper.find(".ant-input-number");
-      expect(limitInput.exists()).toBe(true);
-      expect(limitInput.props().className).toContain("ant-input-number");
+    it("should not show a separate limit input", () => {
+      const limitInput = wrapper.find(".limitInput");
+      expect(limitInput.exists()).toBe(false);
     });
 
-    it("should show the CodeMirror editor for JSON filtering", () => {
+    it("should show the CodeMirror editor with $limit in default JSON", () => {
       const codeMirror = wrapper.find(".react-codemirror2");
       expect(codeMirror.exists()).toBe(true);
       const cmInstance = wrapper.find("Controlled").prop("options");
@@ -181,6 +197,12 @@ describe("EntryDetail", () => {
           lineNumbers: true,
         }),
       );
+
+      const cmValue = wrapper.find("Controlled").prop("value");
+      expect(cmValue).toContain("$limit");
+
+      const exampleText = wrapper.find(".jsonExample").at(0).text();
+      expect(exampleText).toContain("$limit");
     });
   });
 

--- a/src/Views/BucketPanel/EntryDetail.tsx
+++ b/src/Views/BucketPanel/EntryDetail.tsx
@@ -376,7 +376,7 @@ export default function EntryDetail(props: Readonly<Props>) {
           />
           {whenError && <Alert type="error" message={whenError} />}
           <Typography.Text type="secondary" className="jsonExample">
-            {'Example: {"$limit": 10, "&label_name": { "$gt": 10 }}'}
+            {'Example: {"&label_name": { "$gt": 10 }, "$limit": 10 }'}
             <br />
             <a
               href="https://www.reduct.store/docs/conditional-query"

--- a/src/Views/BucketPanel/EntryDetail.tsx
+++ b/src/Views/BucketPanel/EntryDetail.tsx
@@ -56,11 +56,13 @@ export default function EntryDetail(props: Readonly<Props>) {
   const [records, setRecords] = useState<ReadableRecord[]>([]);
   const [start, setStart] = useState<bigint | undefined>(undefined);
   const [end, setEnd] = useState<bigint | undefined>(undefined);
-  const [limit, setLimit] = useState<number | undefined>(10);
+
   const [showUnix, setShowUnix] = useState(false);
   const [entryInfo, setEntryInfo] = useState<EntryInfo>();
   const [isLoading, setIsLoading] = useState(true);
-  const [whenCondition, setWhenCondition] = useState<string>("");
+  const [whenCondition, setWhenCondition] = useState<string>(
+    '{\n  "$limit": 10\n}',
+  );
   const [whenError, setWhenError] = useState<string>("");
   const [isUploadModalVisible, setIsUploadModalVisible] = useState(false);
   const [isEditLabelsModalVisible, setIsEditLabelsModalVisible] =
@@ -73,14 +75,13 @@ export default function EntryDetail(props: Readonly<Props>) {
   // Provide a default value for permissions
   const permissions = props.permissions || { write: [], fullAccess: false };
 
-  const getRecords = async (start?: bigint, end?: bigint, limit?: number) => {
+  const getRecords = async (start?: bigint, end?: bigint) => {
     setIsLoading(true);
     setRecords([]);
     setWhenError("");
     try {
       const bucket = await props.client.getBucket(bucketName);
       const options = new QueryOptions();
-      options.limit = limit;
       options.head = true;
       options.strict = true;
       if (whenCondition.trim()) options.when = JSON.parse(whenCondition);
@@ -97,7 +98,7 @@ export default function EntryDetail(props: Readonly<Props>) {
   };
   const handleFetchRecordsClick = () => {
     if (!isLoading) {
-      getRecords(start, end, limit);
+      getRecords(start, end);
     }
   };
 
@@ -134,7 +135,7 @@ export default function EntryDetail(props: Readonly<Props>) {
       await bucket.removeRecord(entryName, BigInt(recordToDelete.key));
       message.success("Record deleted successfully");
       setIsDeleteModalVisible(false);
-      getRecords(start, end, limit);
+      getRecords(start, end);
     } catch (err) {
       console.error(err);
       message.error("Failed to delete record");
@@ -149,7 +150,7 @@ export default function EntryDetail(props: Readonly<Props>) {
 
   const handleLabelsUpdated = () => {
     // Refresh the records to show updated labels
-    getRecords(start, end, limit);
+    getRecords(start, end);
   };
 
   const handleDateChange = (dates: any) => {
@@ -187,7 +188,7 @@ export default function EntryDetail(props: Readonly<Props>) {
   }, []);
 
   useEffect(() => {
-    getRecords(start, end, limit);
+    getRecords(start, end);
   }, [bucketName, entryName]);
 
   const columns = [
@@ -285,7 +286,7 @@ export default function EntryDetail(props: Readonly<Props>) {
           availableEntries={availableEntries}
           onUploadSuccess={() => {
             setIsUploadModalVisible(false);
-            getRecords(start, end, limit);
+            getRecords(start, end);
           }}
         />
       </Modal>
@@ -350,13 +351,6 @@ export default function EntryDetail(props: Readonly<Props>) {
               className="datePicker"
             />
           )}
-          <InputNumber
-            min={1}
-            addonBefore="Limit"
-            onChange={(value) => setLimit(value ? Number(value) : undefined)}
-            className="limitInput"
-            defaultValue={limit}
-          />
         </div>
         <div className="jsonFilterSection">
           <Typography.Text>Filter Records (JSON):</Typography.Text>
@@ -382,7 +376,7 @@ export default function EntryDetail(props: Readonly<Props>) {
           />
           {whenError && <Alert type="error" message={whenError} />}
           <Typography.Text type="secondary" className="jsonExample">
-            {'Example: {"&label_name": { "$gt": 10 }}'}
+            {'Example: {"$limit": 10, "&label_name": { "$gt": 10 }}'}
             <br />
             <a
               href="https://www.reduct.store/docs/conditional-query"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature enhancement

### What was changed?

- Removed the separate limit input field from the Fetch Records panel
- Added `$limit` parameter directly to the default JSON query condition
- Updated example text to show users how to use the `$limit` operator
- Updated tests to match these changes


### Related issues

#99 Remove "limit" field from Fetch Records Panel

### Does this PR introduce a breaking change?

Yes - users will need to use the `$limit` operator in their JSON query conditions instead of the separate limit field. This requires ReductStore server v1.15+.

### Other information:
