### PR TITLE
When condition editor made disabled for provisioned replication settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- When condition editor disabled for provisioned replication settings, [PR-103](https://github.com/reductstore/web-console/pull/103)
+
 ## [1.10.0] - 2025-05-07
 
 ### Added:
@@ -19,8 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.9.2] - 2025-05-02
 
 ### Fixed
-
-- When condition editor made disabled for provisioned replication settings, [PR-103](https://github.com/reductstore/web-console/pull/103)
 
 - Update RuductStore SDK with fixed start/stop query parameters, [PR-97](https://github.com/reductstore/web-console/pull/97)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- When condition editor made disabled for provisioned replication settings, [PR-103](https://github.com/reductstore/web-console/pull/103)
+
 - Update RuductStore SDK with fixed start/stop query parameters, [PR-97](https://github.com/reductstore/web-console/pull/97)
 
 ## [1.9.1] - 2025-04-03
@@ -83,9 +85,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.0] - 2024-03-01
 
-### Added:
+### Fixed
 
-- RS-47: New view in the console to manage replications, [PR-62](https://github.com/reductstore/web-console/pull/62)
+- Fix bug where "When condition" editor wasn't disabled for provisioned replication tasks when they are configured via environment variables, [PR-XX](https://github.com/reductstore/web-console/pull/XX)
+
+### Added
+
+- Added comprehensive documentation on provisioning replications using environment variables in PROVISIONED_REPLICATIONS.md
+- Added example docker-compose configuration showing how to set up provisioned replications, [PR-62](https://github.com/reductstore/web-console/pull/62)
 
 ### Fixed:
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build": "REACT_APP_VERSION=$npm_package_version react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-app-rewired eject",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint . --ext ts,tsx --ignore-path .gitignore",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check ."
   },

--- a/src/Components/Bucket/BucketCard.test.tsx
+++ b/src/Components/Bucket/BucketCard.test.tsx
@@ -2,7 +2,6 @@ import { mockJSDOM, waitUntilFind } from "../../Helpers/TestHelpers";
 import { mount } from "enzyme";
 import BucketCard from "./BucketCard";
 import { BucketInfo, Client } from "reduct-js";
-import { UploadOutlined } from "@ant-design/icons";
 
 describe("BucketCard", () => {
   beforeEach(() => mockJSDOM());
@@ -191,9 +190,9 @@ describe("BucketCard", () => {
           hasWritePermission={false}
         />,
       );
-      await wrapper.update();
+      wrapper.update();
+
       const uploadButton = wrapper.find("UploadOutlined[title='Upload File']");
-      const removeButton = wrapper.find("DeleteOutlined[title='Remove']");
       expect(uploadButton.length).toEqual(0);
     });
 

--- a/src/Components/Entry/UploadFileForm.test.tsx
+++ b/src/Components/Entry/UploadFileForm.test.tsx
@@ -64,8 +64,11 @@ async function attachFile(
   // Set the file
   await act(async () => {
     const onChange = uploadDragger.prop("onChange");
-    expect(onChange).toBeDefined();
-    onChange!({
+    if (!onChange) {
+      throw new Error("onChange prop is not defined");
+    }
+
+    onChange({
       file: mockFile,
       fileList: [mockFile],
     });
@@ -300,7 +303,11 @@ describe("UploadFileForm", () => {
     await act(async () => {
       const onChange = uploadDragger.prop("onChange");
       expect(onChange).toBeDefined();
-      onChange!({
+      if (!onChange) {
+        throw new Error("onChange prop is not defined");
+      }
+
+      onChange({
         file: mockFile,
         fileList: [mockFile],
       });
@@ -316,7 +323,11 @@ describe("UploadFileForm", () => {
     await act(async () => {
       const onChange = uploadDragger.prop("onChange");
       expect(onChange).toBeDefined();
-      onChange!({
+      if (!onChange) {
+        throw new Error("onChange prop is not defined");
+      }
+
+      onChange({
         file: { ...mockFile, status: "removed" } as UploadFile,
         fileList: [],
       });

--- a/src/Components/Replication/ReplicationSettingsForm.test.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.test.tsx
@@ -198,4 +198,79 @@ describe("Replication::ReplicationSettingsForm", () => {
       .filterWhere((node) => node.text() === "Update Replication");
     expect(button.prop("disabled")).toBe(true);
   });
+
+  it("verifies CodeMirror is non-editable in read-only mode", () => {
+    wrapper = mount(
+      <MemoryRouter>
+        <ReplicationSettingsForm
+          client={client}
+          onCreated={() => {}}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          replicationName={"TestReplication"}
+          readOnly={true}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(wrapper.find(ReplicationSettingsForm).prop("readOnly")).toBe(true);
+  });
+
+  it("verifies When condition JSON editor respects readOnly property", async () => {
+    wrapper = mount(
+      <MemoryRouter>
+        <ReplicationSettingsForm
+          client={client}
+          onCreated={() => {}}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          replicationName={"TestReplication"}
+          readOnly={true}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitUntilFind(wrapper, "form");
+
+    const component = wrapper.find(ReplicationSettingsForm).instance() as any;
+
+    const setStateSpy = jest.spyOn(component, "setState");
+
+    const initialFormattedWhen = component.state.formattedWhen;
+
+    component.handleWhenConditionChange('{"test": "value"}');
+
+    expect(setStateSpy).not.toHaveBeenCalled();
+
+    expect(component.state.formattedWhen).toEqual(initialFormattedWhen);
+
+    setStateSpy.mockRestore();
+  });
+
+  it("verifies handleWhenConditionChange functionality when not in read-only mode", async () => {
+    wrapper = mount(
+      <MemoryRouter>
+        <ReplicationSettingsForm
+          client={client}
+          onCreated={() => {}}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          replicationName={"TestReplication"}
+          readOnly={false}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitUntilFind(wrapper, "form");
+
+    const component = wrapper.find(ReplicationSettingsForm).instance() as any;
+
+    const setStateSpy = jest.spyOn(component, "setState");
+
+    const newValue = '{"test": "value"}';
+    component.handleWhenConditionChange(newValue);
+
+    expect(setStateSpy).toHaveBeenCalled();
+
+    expect(component.state.formattedWhen).toEqual(newValue);
+
+    setStateSpy.mockRestore();
+  });
 });

--- a/src/Components/Replication/ReplicationSettingsForm.test.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.test.tsx
@@ -54,9 +54,7 @@ describe("Replication::ReplicationSettingsForm", () => {
     });
 
     client.updateReplication = jest.fn().mockResolvedValue(undefined);
-
     client.createReplication = jest.fn().mockResolvedValue(undefined);
-
     client.getBucket = jest.fn().mockResolvedValue({
       getEntryList: jest
         .fn()
@@ -96,7 +94,6 @@ describe("Replication::ReplicationSettingsForm", () => {
     expect(wrapper.find({ name: "dstHost" }).exists()).toBeTruthy();
     expect(wrapper.find({ name: "dstToken" }).exists()).toBeTruthy();
     expect(wrapper.find({ name: "entries" }).exists()).toBeTruthy();
-
     expect(wrapper.find({ name: "eachN" }).exists()).toBeTruthy();
     expect(wrapper.find({ name: "eachS" }).exists()).toBeTruthy();
   });
@@ -204,7 +201,7 @@ describe("Replication::ReplicationSettingsForm", () => {
       <MemoryRouter>
         <ReplicationSettingsForm
           client={client}
-          onCreated={() => {}}
+          onCreated={() => null}
           sourceBuckets={["Bucket1", "Bucket2"]}
           replicationName={"TestReplication"}
           readOnly={true}
@@ -220,7 +217,7 @@ describe("Replication::ReplicationSettingsForm", () => {
       <MemoryRouter>
         <ReplicationSettingsForm
           client={client}
-          onCreated={() => {}}
+          onCreated={() => null}
           sourceBuckets={["Bucket1", "Bucket2"]}
           replicationName={"TestReplication"}
           readOnly={true}
@@ -231,15 +228,12 @@ describe("Replication::ReplicationSettingsForm", () => {
     await waitUntilFind(wrapper, "form");
 
     const component = wrapper.find(ReplicationSettingsForm).instance() as any;
-
     const setStateSpy = jest.spyOn(component, "setState");
-
     const initialFormattedWhen = component.state.formattedWhen;
 
     component.handleWhenConditionChange('{"test": "value"}');
 
     expect(setStateSpy).not.toHaveBeenCalled();
-
     expect(component.state.formattedWhen).toEqual(initialFormattedWhen);
 
     setStateSpy.mockRestore();
@@ -250,7 +244,7 @@ describe("Replication::ReplicationSettingsForm", () => {
       <MemoryRouter>
         <ReplicationSettingsForm
           client={client}
-          onCreated={() => {}}
+          onCreated={() => null}
           sourceBuckets={["Bucket1", "Bucket2"]}
           replicationName={"TestReplication"}
           readOnly={false}
@@ -261,14 +255,12 @@ describe("Replication::ReplicationSettingsForm", () => {
     await waitUntilFind(wrapper, "form");
 
     const component = wrapper.find(ReplicationSettingsForm).instance() as any;
-
     const setStateSpy = jest.spyOn(component, "setState");
-
     const newValue = '{"test": "value"}';
+
     component.handleWhenConditionChange(newValue);
 
     expect(setStateSpy).toHaveBeenCalled();
-
     expect(component.state.formattedWhen).toEqual(newValue);
 
     setStateSpy.mockRestore();

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -478,6 +478,7 @@ export default class ReplicationSettingsFormReplication extends React.Component<
                   viewportMargin: Infinity,
                   matchBrackets: true,
                   autoCloseBrackets: true,
+                  readOnly: readOnly || false,
                 }}
                 onBeforeChange={(editor: any, data: any, value: string) => {
                   this.handleWhenConditionChange(value);

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -264,6 +264,9 @@ export default class ReplicationSettingsFormReplication extends React.Component<
   };
 
   handleWhenConditionChange = (value: string) => {
+    if (this.props.readOnly) {
+      return;
+    }
     this.setState((prevState) => ({ ...prevState, formattedWhen: value }));
   };
 


### PR DESCRIPTION

Closes #100 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug

### What was changed?

Bug fix - Ensures that the CodeMirror editor for the "When condition" in ReplicationSettingsForm is properly disabled for provisioned replication.

### Related issues

(Add links to related issues)

### Does this PR introduce a breaking change?

No

### Other information:
