### PR TITLE
Hide condition fields in replication settings when `each_n` and `each_s` are null or undefined,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Hide condition fields in replication settings when `each_n` and `each_s` are null or undefined, [PR-106](https://github.com/reductstore/web-console/pull/106)
+
 ## [1.10.1] - 2025-05-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
 - Hide condition fields in replication settings when `each_n` and `each_s` are null or undefined, [PR-106](https://github.com/reductstore/web-console/pull/106)
 

--- a/src/Components/Replication/ReplicationSettingsForm.test.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.test.tsx
@@ -265,4 +265,120 @@ describe("Replication::ReplicationSettingsForm", () => {
 
     setStateSpy.mockRestore();
   });
+
+  it("shows condition fields when settings.eachN is defined", async () => {
+    const mockSettings = ReplicationSettings.parse({
+      src_bucket: "Bucket1",
+      dst_bucket: "destinationBucket",
+      dst_host: "destinationHost",
+      dst_token: "destinationToken",
+      entries: ["entry1", "entry2"],
+      include: {},
+      exclude: {},
+      each_n: 42n,
+      // each_s is undefined
+    });
+    const mockReplicationInfo = ReplicationInfo.parse({
+      name: "TestReplication",
+      is_active: true,
+      is_provisioned: true,
+      pending_records: BigInt(100),
+    });
+    client.getReplication = jest.fn().mockResolvedValue({
+      info: mockReplicationInfo,
+      settings: mockSettings,
+      diagnostics: undefined,
+    });
+    wrapper = mount(
+      <MemoryRouter>
+        <ReplicationSettingsForm
+          client={client}
+          onCreated={() => null}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          replicationName={"TestReplication"}
+          readOnly={false}
+        />
+      </MemoryRouter>,
+    );
+    await waitUntilFind(wrapper, "form");
+    expect(wrapper.text()).toContain("Every N-th record");
+    expect(wrapper.text()).toContain("Every S seconds");
+  });
+
+  it("shows condition fields when settings.eachS is defined", async () => {
+    const mockSettings = ReplicationSettings.parse({
+      src_bucket: "Bucket1",
+      dst_bucket: "destinationBucket",
+      dst_host: "destinationHost",
+      dst_token: "destinationToken",
+      entries: ["entry1", "entry2"],
+      include: {},
+      exclude: {},
+      // each_n is undefined
+      each_s: 1.23,
+    });
+    const mockReplicationInfo = ReplicationInfo.parse({
+      name: "TestReplication",
+      is_active: true,
+      is_provisioned: true,
+      pending_records: BigInt(100),
+    });
+    client.getReplication = jest.fn().mockResolvedValue({
+      info: mockReplicationInfo,
+      settings: mockSettings,
+      diagnostics: undefined,
+    });
+    wrapper = mount(
+      <MemoryRouter>
+        <ReplicationSettingsForm
+          client={client}
+          onCreated={() => null}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          replicationName={"TestReplication"}
+          readOnly={false}
+        />
+      </MemoryRouter>,
+    );
+    await waitUntilFind(wrapper, "form");
+    expect(wrapper.text()).toContain("Every N-th record");
+    expect(wrapper.text()).toContain("Every S seconds");
+  });
+
+  it("hides condition fields when neither settings.eachN nor settings.eachS is defined", async () => {
+    const mockSettings = ReplicationSettings.parse({
+      src_bucket: "Bucket1",
+      dst_bucket: "destinationBucket",
+      dst_host: "destinationHost",
+      dst_token: "destinationToken",
+      entries: ["entry1", "entry2"],
+      include: {},
+      exclude: {},
+      // both each_n and each_s are undefined
+    });
+    const mockReplicationInfo = ReplicationInfo.parse({
+      name: "TestReplication",
+      is_active: true,
+      is_provisioned: true,
+      pending_records: BigInt(100),
+    });
+    client.getReplication = jest.fn().mockResolvedValue({
+      info: mockReplicationInfo,
+      settings: mockSettings,
+      diagnostics: undefined,
+    });
+    wrapper = mount(
+      <MemoryRouter>
+        <ReplicationSettingsForm
+          client={client}
+          onCreated={() => null}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          replicationName={"TestReplication"}
+          readOnly={false}
+        />
+      </MemoryRouter>,
+    );
+    await waitUntilFind(wrapper, "form");
+    expect(wrapper.text()).not.toContain("Every N-th record");
+    expect(wrapper.text()).not.toContain("Every S seconds");
+  });
 });

--- a/src/Components/Replication/ReplicationSettingsForm.test.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.test.tsx
@@ -381,4 +381,44 @@ describe("Replication::ReplicationSettingsForm", () => {
     expect(wrapper.text()).not.toContain("Every N-th record");
     expect(wrapper.text()).not.toContain("Every S seconds");
   });
+
+  it("hides condition fields when settings.eachN and settings.eachS are both null", async () => {
+    const mockSettings = ReplicationSettings.parse({
+      src_bucket: "Bucket1",
+      dst_bucket: "destinationBucket",
+      dst_host: "destinationHost",
+      dst_token: "destinationToken",
+      entries: ["entry1", "entry2"],
+      include: {},
+      exclude: {},
+      // Simulating null for each_n and each_s
+      each_n: null as unknown as bigint,
+      each_s: null as unknown as number,
+    });
+    const mockReplicationInfo = ReplicationInfo.parse({
+      name: "TestReplication",
+      is_active: true,
+      is_provisioned: true,
+      pending_records: BigInt(100),
+    });
+    client.getReplication = jest.fn().mockResolvedValue({
+      info: mockReplicationInfo,
+      settings: mockSettings,
+      diagnostics: undefined,
+    });
+    wrapper = mount(
+      <MemoryRouter>
+        <ReplicationSettingsForm
+          client={client}
+          onCreated={() => null}
+          sourceBuckets={["Bucket1", "Bucket2"]}
+          replicationName={"TestReplication"}
+          readOnly={false}
+        />
+      </MemoryRouter>,
+    );
+    await waitUntilFind(wrapper, "form");
+    expect(wrapper.text()).not.toContain("Every N-th record");
+    expect(wrapper.text()).not.toContain("Every S seconds");
+  });
 });

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -433,7 +433,7 @@ export default class ReplicationSettingsFormReplication extends React.Component<
             </Col>
           </Row>
 
-          <b>Condition</b>
+          <b>Conditions</b>
           {(this.state.settings?.eachN != null ||
             this.state.settings?.eachS != null) && (
             <>

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -434,8 +434,8 @@ export default class ReplicationSettingsFormReplication extends React.Component<
           </Row>
 
           <b>Condition</b>
-          {(this.state.settings?.eachN !== undefined ||
-            this.state.settings?.eachS !== undefined) && (
+          {(this.state.settings?.eachN != null ||
+            this.state.settings?.eachS != null) && (
             <>
               <Row>
                 <Col span={12}>

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -433,10 +433,10 @@ export default class ReplicationSettingsFormReplication extends React.Component<
             </Col>
           </Row>
 
-          <b>Conditions</b>
-          {(this.state.settings?.eachN != null ||
-            this.state.settings?.eachS != null) && (
+          {this.state.settings?.eachN != null ||
+          this.state.settings?.eachS != null ? (
             <>
+              <b>Conditions</b>
               <Row>
                 <Col span={12}>
                   <Form.Item
@@ -471,12 +471,17 @@ export default class ReplicationSettingsFormReplication extends React.Component<
                 </Col>
               </Row>
             </>
+          ) : (
+            <>
+              <b>Conditional Replication</b>
+            </>
           )}
+
           <Form.Item
             label={
               <span>
                 When&nbsp;
-                <Tooltip title="Enter conditions to filter records by labels.">
+                <Tooltip title="Define JSON-based rules to filter and control record replication. Supports label comparisons (e.g., &score > 0.5) and aggregation (e.g., every N-th record).">
                   <InfoCircleOutlined />
                 </Tooltip>
               </span>
@@ -523,15 +528,26 @@ export default class ReplicationSettingsFormReplication extends React.Component<
               <></>
             )}
             <Typography.Text type="secondary" className="jsonExample">
-              {'Example: {"&label_name": { "$gt": 10 }}'}
+              Example: <code>{'{"&anomaly": { "$eq": 1 }}'}</code>
               <br />
-              <a
-                href="https://www.reduct.store/docs/conditional-query"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Query Reference Documentation
-              </a>
+              Use <code>&label</code> for standard labels and{" "}
+              <code>@label</code> for computed labels. Combine with operators
+              like <code>$eq</code>, <code>$gt</code>, <code>$lt</code>,{" "}
+              <code>$and</code>, etc.
+              <br />
+              You can also use aggregation operators:
+              <code>$each_n</code> (every N-th record) and <code>$each_t</code>{" "}
+              (every N seconds) to control replication frequency.
+              <br />
+              <strong>
+                <a
+                  href="https://www.reduct.store/docs/conditional-query"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View Conditional Query Reference →
+                </a>
+              </strong>
             </Typography.Text>
           </Form.Item>
 

--- a/src/Components/Replication/ReplicationSettingsForm.tsx
+++ b/src/Components/Replication/ReplicationSettingsForm.tsx
@@ -433,42 +433,55 @@ export default class ReplicationSettingsFormReplication extends React.Component<
             </Col>
           </Row>
 
-          <b>Conditions</b>
-          <Row>
-            <Col span={12}>
-              <Form.Item
-                label={
-                  <span>
-                    Every N-th record&nbsp;
-                    <Tooltip title="If set, only every N-th record is replicated.">
-                      <InfoCircleOutlined />
-                    </Tooltip>
-                  </span>
-                }
-                name="eachN"
-              >
-                <InputNumber disabled={readOnly} min={1} precision={0} />
-              </Form.Item>
-            </Col>
+          <b>Condition</b>
+          {(this.state.settings?.eachN !== undefined ||
+            this.state.settings?.eachS !== undefined) && (
+            <>
+              <Row>
+                <Col span={12}>
+                  <Form.Item
+                    label={
+                      <span>
+                        Every N-th record&nbsp;
+                        <Tooltip title="If set, only every N-th record is replicated.">
+                          <InfoCircleOutlined />
+                        </Tooltip>
+                      </span>
+                    }
+                    name="eachN"
+                  >
+                    <InputNumber disabled={readOnly} min={1} precision={0} />
+                  </Form.Item>
+                </Col>
 
-            <Col span={12}>
-              <Form.Item
-                label={
-                  <span>
-                    Every S seconds&nbsp;
-                    <Tooltip title="If set, only one record is replicated every S seconds. Can be float.">
-                      <InfoCircleOutlined />
-                    </Tooltip>
-                  </span>
-                }
-                name="eachS"
-              >
-                <InputNumber disabled={readOnly} min={0.000001} />
-              </Form.Item>
-            </Col>
-          </Row>
-
-          <Form.Item label={<span>When Condition</span>}>
+                <Col span={12}>
+                  <Form.Item
+                    label={
+                      <span>
+                        Every S seconds&nbsp;
+                        <Tooltip title="If set, only one record is replicated every S seconds. Can be float.">
+                          <InfoCircleOutlined />
+                        </Tooltip>
+                      </span>
+                    }
+                    name="eachS"
+                  >
+                    <InputNumber disabled={readOnly} min={0.000001} />
+                  </Form.Item>
+                </Col>
+              </Row>
+            </>
+          )}
+          <Form.Item
+            label={
+              <span>
+                When&nbsp;
+                <Tooltip title="Enter conditions to filter records by labels.">
+                  <InfoCircleOutlined />
+                </Tooltip>
+              </span>
+            }
+          >
             {!isTestEnvironment ? (
               <CodeMirror
                 className="jsonEditor"

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -10,7 +10,7 @@ import {
   EditOutlined,
   DeleteOutlined,
 } from "@ant-design/icons";
-import { message, Modal } from "antd";
+import { message } from "antd";
 import React from "react";
 
 type RemoveRecordFn = (entry: string, ts: bigint) => Promise<void>;
@@ -39,7 +39,7 @@ import "codemirror/lib/codemirror.css";
 import "codemirror/mode/javascript/javascript";
 
 // Mock the useParams hook for all tests
-let mockParams = {
+const mockParams = {
   bucketName: "testBucket",
   entryName: "testEntry",
 };


### PR DESCRIPTION
Closes #105 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Hide legacy feature

### What was changed?

Hid the condition fields when `each_n` and `each_s` are null or undefined.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
