### PR TITLE
Use dynamic public URL for static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .vscode
+.env


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

When rendering images (e.g. the logo) from the static folder, we use the constant variable `PUBLIC_URL`, which is set to '/ui'.
However, this does not work when we use the embedded console from a ReductStore instance with a custom API path.
The PR fixes this issue by using the dynamic public URL, which is deduced from the window location.


### Related issues

https://github.com/reductstore/reductstore/issues/839

### Does this PR introduce a breaking change?

No

### Other information:
