### PR TITLE
45 bug copy and close button for a new token doesnt work

### DIFF
--- a/src/Views/SecurityPanel/TokenDetail.test.tsx
+++ b/src/Views/SecurityPanel/TokenDetail.test.tsx
@@ -71,7 +71,7 @@ describe("TokenDetail", () => {
     expect(error.hostNodes().text()).toBe("error");
   });
 
-  it("should remove a token", async () => {
+  it("should show remove confirmation modal", async () => {
     client.deleteToken = jest.fn().mockResolvedValue(undefined);
     const view = mount(
       <MemoryRouter initialEntries={["/tokens/new_token"]}>
@@ -82,9 +82,17 @@ describe("TokenDetail", () => {
     );
 
     const removeButton = await waitUntilFind(view, ".RemoveButton");
-    removeButton.hostNodes().props().onClick();
+    await act(async () => {
+      removeButton.hostNodes().props().onClick();
+    });
+    view.update();
 
-    // No idea how to test modal with confirmation
+    const confirmationText = view
+      .find("p")
+      .filterWhere((n) => n.text().includes("For confirmation type"));
+
+    expect(confirmationText.exists()).toBe(true);
+    expect(confirmationText.text()).toBe("For confirmation type token-1");
   });
 
   it("should disable remove button if provisioned", async () => {

--- a/src/Views/SecurityPanel/TokenDetail.test.tsx
+++ b/src/Views/SecurityPanel/TokenDetail.test.tsx
@@ -3,6 +3,7 @@ import { Client, Token } from "reduct-js";
 import { mockJSDOM, waitUntilFind } from "../../Helpers/TestHelpers";
 import { mount } from "enzyme";
 import TokenDetail from "./TokenDetail";
+import { MemoryRouter, Route } from "react-router-dom";
 
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
@@ -26,11 +27,18 @@ describe("TokenDetail", () => {
         read: ["bucket-1"],
         write: ["bucket-2"],
       },
+      value: "mock-token-value",
     } as Token);
   });
 
   it("should show token details", async () => {
-    const view = mount(<TokenDetail client={client} />);
+    const view = mount(
+      <MemoryRouter initialEntries={["/tokens/new_token"]}>
+        <Route path="/tokens/:name">
+          <TokenDetail client={client} />
+        </Route>
+      </MemoryRouter>,
+    );
 
     const input = await waitUntilFind(view, { name: "name" });
     expect(input.hostNodes().props().value).toBe("token-1");
@@ -51,7 +59,13 @@ describe("TokenDetail", () => {
 
   it("should show error", async () => {
     client.getToken = jest.fn().mockRejectedValue(new Error("error"));
-    const view = mount(<TokenDetail client={client} />);
+    const view = mount(
+      <MemoryRouter initialEntries={["/tokens/new_token"]}>
+        <Route path="/tokens/:name">
+          <TokenDetail client={client} />
+        </Route>
+      </MemoryRouter>,
+    );
 
     const error = await waitUntilFind(view, ".Alert");
     expect(error.hostNodes().text()).toBe("error");
@@ -59,7 +73,13 @@ describe("TokenDetail", () => {
 
   it("should remove a token", async () => {
     client.deleteToken = jest.fn().mockResolvedValue(undefined);
-    const view = mount(<TokenDetail client={client} />);
+    const view = mount(
+      <MemoryRouter initialEntries={["/tokens/new_token"]}>
+        <Route path="/tokens/:name">
+          <TokenDetail client={client} />
+        </Route>
+      </MemoryRouter>,
+    );
 
     const removeButton = await waitUntilFind(view, ".RemoveButton");
     removeButton.hostNodes().props().onClick();
@@ -73,7 +93,13 @@ describe("TokenDetail", () => {
       createdAt: 100000,
       isProvisioned: true,
     } as Token);
-    const view = mount(<TokenDetail client={client} />);
+    const view = mount(
+      <MemoryRouter initialEntries={["/tokens/new_token"]}>
+        <Route path="/tokens/:name">
+          <TokenDetail client={client} />
+        </Route>
+      </MemoryRouter>,
+    );
 
     const removeButton = await waitUntilFind(view, ".RemoveButton");
     expect(removeButton.hostNodes().props().disabled).toBeTruthy();

--- a/src/Views/SecurityPanel/TokenDetail.test.tsx
+++ b/src/Views/SecurityPanel/TokenDetail.test.tsx
@@ -95,6 +95,46 @@ describe("TokenDetail", () => {
     expect(confirmationText.text()).toBe("For confirmation type token-1");
   });
 
+  it("should remove a token", async () => {
+    const mockDeleteToken = jest.fn().mockResolvedValue(undefined);
+    client.deleteToken = mockDeleteToken;
+
+    const view = mount(
+      <MemoryRouter initialEntries={["/tokens/token-1"]}>
+        <Route path="/tokens/:name">
+          <TokenDetail client={client} />
+        </Route>
+      </MemoryRouter>,
+    );
+
+    const removeButton = await waitUntilFind(view, ".RemoveButton");
+    await act(async () => {
+      removeButton.hostNodes().props().onClick();
+    });
+    view.update();
+
+    const renameModal = view.find('div[data-testid="remove-token-modal"]');
+    expect(renameModal.exists()).toBe(true);
+
+    const input = renameModal.find('input[data-testid="remove-confirm-input"]');
+    act(() => {
+      input.simulate("change", { target: { value: "token-1" } });
+    });
+    view.update();
+
+    const okButton = renameModal
+      .find("button")
+      .filterWhere((n) => n.text().includes("Remove Token"));
+    expect(okButton.exists()).toBe(true);
+
+    await act(async () => {
+      okButton.simulate("click");
+    });
+    view.update();
+
+    expect(mockDeleteToken).toHaveBeenCalledWith("token-1");
+  });
+
   it("should disable remove button if provisioned", async () => {
     client.getToken = jest.fn().mockResolvedValue({
       name: "token-1",

--- a/src/Views/SecurityPanel/TokenDetail.tsx
+++ b/src/Views/SecurityPanel/TokenDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Client, Token } from "reduct-js";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory, useLocation, useParams } from "react-router-dom";
 import {
   Alert,
   Button,
@@ -19,7 +19,8 @@ interface Props {
 }
 
 function useQueryParams() {
-  const params = new URLSearchParams(window ? window.location.search : {});
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
 
   return new Proxy(params, {
     get(target, prop) {
@@ -167,7 +168,11 @@ export default function TokenDetail(props: Readonly<Props>) {
       <Space>
         <Button onClick={() => history.push("/tokens")}>Back</Button>
         {isNew ? (
-          <Button type={"primary"} onClick={() => createToken()}>
+          <Button
+            className="CreateButton"
+            type={"primary"}
+            onClick={() => createToken()}
+          >
             Create
           </Button>
         ) : (

--- a/src/Views/SecurityPanel/TokenDetail.tsx
+++ b/src/Views/SecurityPanel/TokenDetail.tsx
@@ -233,7 +233,7 @@ export default function TokenDetail(props: Readonly<Props>) {
               type="success"
               message="This is your token value. Please, save it somewhere, because it will not be shown again."
             />
-            {tokenError ? (
+            {tokenError && (
               <Alert
                 className="Alert"
                 message={tokenError}
@@ -241,14 +241,12 @@ export default function TokenDetail(props: Readonly<Props>) {
                 closable
                 onClose={() => setTokenError(undefined)}
               />
-            ) : (
-              <div />
             )}
             <Input.TextArea
               value={tokenValue ? tokenValue : ""}
-              readOnly={true}
-              rows={4}
-            ></Input.TextArea>
+              readOnly
+              autoSize={{ minRows: 4 }}
+            />
           </Space>
         </Modal>
       </Space>,

--- a/src/Views/SecurityPanel/TokenDetail.tsx
+++ b/src/Views/SecurityPanel/TokenDetail.tsx
@@ -193,9 +193,10 @@ export default function TokenDetail(props: Readonly<Props>) {
           onCancel={() => setConfirmRemove(false)}
           closable={false}
           title={`Remove token "${token.name}"?`}
-          okText="Remove"
+          okText="Remove Token"
           confirmLoading={!confirmName}
           okType="danger"
+          data-testid="remove-token-modal"
         >
           <p>
             For confirmation type <b>{token.name}</b>
@@ -203,7 +204,8 @@ export default function TokenDetail(props: Readonly<Props>) {
           <Form.Item name="confirm">
             <Input
               onChange={(e) => setConfirmName(token?.name === e.target.value)}
-            ></Input>
+              data-testid="remove-confirm-input"
+            />
           </Form.Item>
         </Modal>
 


### PR DESCRIPTION
Closes #45 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Handle clipboard copy errors when displaying a token. Show an error message if `navigator.clipboard.writeText` fails.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
