### PR TITLE
Implement time range presets for EntryDetail

### DIFF
--- a/src/Views/BucketPanel/EntryDetail.css
+++ b/src/Views/BucketPanel/EntryDetail.css
@@ -23,6 +23,10 @@
   width: 410px;
 }
 
+.formatSelect {
+  width: 120px;
+}
+
 .limitInput {
   width: 120px;
 }

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -163,28 +163,25 @@ describe("EntryDetail", () => {
     beforeEach(async () => {
       await act(async () => {
         jest.runOnlyPendingTimers();
-        await waitUntil(
-          () => wrapper.update().find(".ant-checkbox").length > 0,
-        );
+        await waitUntil(() => wrapper.update().find(".ant-select").length > 0);
       });
     });
 
-    it("should show the Unix timestamp toggle", () => {
-      const toggle = wrapper.find(".ant-checkbox-wrapper");
-      expect(toggle.exists()).toBe(true);
-      expect(toggle.text()).toContain("Unix Timestamp");
+    it("should show the display format select", () => {
+      const select = wrapper.find('Select[data-testid="format-select"]');
+      expect(select.exists()).toBe(true);
     });
 
-    it("should show the date picker by default", () => {
-      const datePicker = wrapper.find(".ant-picker-range");
-      expect(datePicker.exists()).toBe(true);
-      expect(datePicker.props().className).toContain("ant-picker-range");
+    it("should show the range dropdown button", () => {
+      const btn = wrapper.find('button[data-testid="range-button"]');
+      expect(btn.exists()).toBe(true);
+      expect(btn.text()).toContain("Select time range");
     });
 
     it("should show the fetch records button", () => {
-      const fetchButton = wrapper.find("button");
+      const fetchButton = wrapper.find(".fetchButton button");
       expect(fetchButton.exists()).toBe(true);
-      expect(fetchButton.at(0).text()).toBe("Fetch Records");
+      expect(fetchButton.text()).toBe("Fetch Records");
     });
 
     it("should not show a separate limit input", () => {
@@ -260,9 +257,10 @@ describe("EntryDetail", () => {
       await waitUntil(() => wrapper.update().find(".ant-table-row").length > 0);
     });
 
-    const checkbox = wrapper.find(".ant-checkbox-input");
+    const select = wrapper.find('Select[data-testid="format-select"]').at(0);
     act(() => {
-      checkbox.simulate("change", { target: { checked: true } });
+      const onChange = select.prop("onChange") as any;
+      if (onChange) onChange("Unix");
     });
 
     const rows = wrapper.find(".ant-table-row");


### PR DESCRIPTION
## Summary
- enhance EntryDetail with display format select
- add preset time ranges via dropdown and custom range picker
- support editable start/stop fields with validation
- update CSS for new controls
- adjust tests for new UI

## Testing
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_687e6e5f4a1c83258fa56ab076ac4b64