### PR TITLE
238 add reductros to builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add sampling ($each_n/$each_t) and limit ($limit) steps to the Data Explorer's Conditional Query builder, [PR-242](https://github.com/reductstore/web-console/pull/242)
+- Add a Transform (ReductROS) step to the Data Explorer's Conditional Query builder, [PR-243](https://github.com/reductstore/web-console/pull/243)
 
 ## 1.16.0 - 2026-08-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3261,9 +3261,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/src/Components/QueryConditionBuilder/ConditionListEditor.tsx
+++ b/src/Components/QueryConditionBuilder/ConditionListEditor.tsx
@@ -1,7 +1,8 @@
-import { Button, Select, Tooltip } from "antd";
+import { Button, Select, Tooltip, Typography } from "antd";
 import { PlusOutlined } from "@ant-design/icons";
 import LabelConditionEditor from "./LabelConditionEditor";
 import { FlatCondition, hasValue } from "../../Helpers/conditionalQueryBuilder";
+import { ROW_LABEL_WIDTH } from "./stepRowLayout";
 
 type ConnectorChoice = "$and" | "$or" | "not";
 
@@ -72,14 +73,21 @@ export default function ConditionListEditor({
               marginBottom: 6,
             }}
           >
-            {index > 0 && (
+            {index > 0 ? (
               <Select
                 popupMatchSelectWidth={false}
                 value={connectorChoiceFor(condition)}
                 options={CONNECTOR_OPTIONS}
                 onChange={(value) => handleConnectorChange(condition.id, value)}
-                style={{ width: 70 }}
+                style={{ width: ROW_LABEL_WIDTH }}
               />
+            ) : (
+              <Typography.Text
+                strong
+                style={{ width: ROW_LABEL_WIDTH, flexShrink: 0, fontSize: 12 }}
+              >
+                Where
+              </Typography.Text>
             )}
             <LabelConditionEditor
               condition={condition}

--- a/src/Components/QueryConditionBuilder/LabelConditionEditor.tsx
+++ b/src/Components/QueryConditionBuilder/LabelConditionEditor.tsx
@@ -6,6 +6,7 @@ import {
   LABEL_OPERATORS,
   isMultiValueOperator,
 } from "../../Helpers/conditionalQueryBuilder";
+import { ROW_INPUT_WIDTH, ROW_GAP, ROW_GROUP_WIDTH } from "./stepRowLayout";
 
 interface LabelConditionEditorProps {
   condition: FlatCondition;
@@ -44,42 +45,45 @@ export default function LabelConditionEditor({
   };
 
   return (
-    <div style={{ display: "flex", gap: 8, flex: 1 }}>
-      <AutoComplete
-        placeholder="label"
-        value={condition.label}
-        options={labelOptions.map((option) => ({ value: option }))}
-        onChange={(value) =>
-          onChange(condition.id, { label: value.replace(/^&/, "") })
-        }
-        style={{ minWidth: 130, flexShrink: 0 }}
-        popupMatchSelectWidth={false}
-      />
-      <Select
-        value={condition.operator}
-        options={LABEL_OPERATORS}
-        onChange={handleOperatorChange}
-        style={{ width: "max-content", minWidth: 48, flexShrink: 0 }}
-        popupMatchSelectWidth={false}
-      />
-      {isMultiValue ? (
-        <Select
-          mode="tags"
-          placeholder="values"
-          tokenSeparators={[","]}
-          value={condition.value as string[]}
-          onChange={(value) => onChange(condition.id, { value })}
-          style={{ flex: 1, minWidth: 130 }}
+    <div style={{ display: "flex", alignItems: "center", gap: ROW_GAP }}>
+      <div style={{ display: "flex", gap: ROW_GAP, width: ROW_GROUP_WIDTH }}>
+        <AutoComplete
+          aria-label="Label"
+          placeholder="label"
+          value={condition.label}
+          options={labelOptions.map((option) => ({ value: option }))}
+          onChange={(value) =>
+            onChange(condition.id, { label: value.replace(/^&/, "") })
+          }
+          style={{ width: ROW_INPUT_WIDTH, flexShrink: 0 }}
           popupMatchSelectWidth={false}
         />
-      ) : (
-        <Input
-          placeholder="value"
-          value={condition.value as string}
-          onChange={(e) => onChange(condition.id, { value: e.target.value })}
-          style={{ flex: 1 }}
+        <Select
+          value={condition.operator}
+          options={LABEL_OPERATORS}
+          onChange={handleOperatorChange}
+          style={{ width: "max-content", minWidth: 48, flexShrink: 0 }}
+          popupMatchSelectWidth={false}
         />
-      )}
+        {isMultiValue ? (
+          <Select
+            mode="tags"
+            placeholder="values"
+            tokenSeparators={[","]}
+            value={condition.value as string[]}
+            onChange={(value) => onChange(condition.id, { value })}
+            style={{ flex: 1, minWidth: 0 }}
+            popupMatchSelectWidth={false}
+          />
+        ) : (
+          <Input
+            placeholder="value"
+            value={condition.value as string}
+            onChange={(e) => onChange(condition.id, { value: e.target.value })}
+            style={{ flex: 1, minWidth: 0 }}
+          />
+        )}
+      </div>
       {removable ? (
         <Button
           aria-label="Remove condition"

--- a/src/Components/QueryConditionBuilder/LimitStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/LimitStepEditor.tsx
@@ -1,5 +1,6 @@
-import { InputNumber } from "antd";
+import { InputNumber, Typography } from "antd";
 import { LimitStep } from "../../Helpers/conditionalQueryBuilder";
+import { ROW_LABEL_WIDTH } from "./stepRowLayout";
 
 interface LimitStepEditorProps {
   step: LimitStep;
@@ -20,6 +21,12 @@ export default function LimitStepEditor({
         minWidth: 0,
       }}
     >
+      <Typography.Text
+        strong
+        style={{ width: ROW_LABEL_WIDTH, flexShrink: 0, fontSize: 12 }}
+      >
+        Count
+      </Typography.Text>
       <InputNumber
         min={1}
         placeholder="max records"

--- a/src/Components/QueryConditionBuilder/LimitStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/LimitStepEditor.tsx
@@ -1,6 +1,6 @@
 import { InputNumber, Typography } from "antd";
 import { LimitStep } from "../../Helpers/conditionalQueryBuilder";
-import { ROW_LABEL_WIDTH } from "./stepRowLayout";
+import { ROW_LABEL_WIDTH, VALUE_INPUT_WIDTH } from "./stepRowLayout";
 
 interface LimitStepEditorProps {
   step: LimitStep;
@@ -32,7 +32,7 @@ export default function LimitStepEditor({
         placeholder="max records"
         value={step.count}
         onChange={(value) => onChange({ count: value ?? undefined })}
-        style={{ width: 140 }}
+        style={{ width: VALUE_INPUT_WIDTH }}
       />
     </div>
   );

--- a/src/Components/QueryConditionBuilder/QueryBlockList.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryBlockList.test.tsx
@@ -231,7 +231,7 @@ describe("QueryBlockList", () => {
     ).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("hides every block until a data source is selected, but keeps Add step reachable and greys out its menu", async () => {
+  it("hides every block except the default Interval step until a data source is selected, but keeps Add step reachable and greys out its menu", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -242,12 +242,26 @@ describe("QueryBlockList", () => {
       />,
     );
     expect(screen.queryByText("Label filter")).toBeNull();
-    expect(screen.queryByText("Sample by time")).toBeNull();
+    expect(screen.getByText("Sample by time")).toBeTruthy();
     expect(screen.getByLabelText("Add step")).not.toBeDisabled();
     await openAddStepMenu();
     expect(
       screen.getByRole("menuitem", { name: "Label filter" }),
     ).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("still hides non-default steps like Limit until a data source is selected", () => {
+    render(
+      <QueryBlockList
+        {...baseProps}
+        blockOrder={["each-t-1", "limit-1"]}
+        conditions={[]}
+        steps={[eachTStep, limitStep]}
+        sourceReady={false}
+      />,
+    );
+    expect(screen.getByText("Sample by time")).toBeTruthy();
+    expect(screen.queryByText("Limit")).toBeNull();
   });
 
   it("calls onRemoveStep with a step's id from its block's remove button", () => {

--- a/src/Components/QueryConditionBuilder/QueryBlockList.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryBlockList.test.tsx
@@ -4,6 +4,10 @@ import type { DragEndEvent } from "@dnd-kit/core";
 import QueryBlockList from "./QueryBlockList";
 import { mockJSDOM } from "../../Helpers/TestHelpers";
 import { FlatCondition, Step } from "../../Helpers/conditionalQueryBuilder";
+import {
+  TRANSFORM_BLOCK_ID,
+  TransformStepEntry,
+} from "../../Helpers/transformStepBuilder";
 
 let capturedOnDragEnd: ((event: DragEndEvent) => void) | undefined;
 
@@ -68,8 +72,31 @@ const baseProps = {
   onAddLimit: noop,
   onAddConditionsBlock: noop,
   onRemoveConditionsBlock: noop,
+  onAddTransformBlock: noop,
+  onRemoveTransformBlock: noop,
+  onAddSection: noop,
+  onRemoveSection: noop,
+  onChangeTopic: noop,
+  onAddEncodeRow: noop,
+  onChangeEncodeRow: noop,
+  onRemoveEncodeRow: noop,
+  onAddAsLabelRow: noop,
+  onChangeAsLabelRow: noop,
+  onRemoveAsLabelRow: noop,
+  onChangeExport: noop,
   onRemoveStep: noop,
   onReorderBlock: noop,
+};
+
+const transformStep: TransformStepEntry = {
+  kind: "ros",
+  ros: {
+    sections: ["filter", "label"],
+    topic: "/robot/odom",
+    encode: [],
+    asLabel: [{ id: "row-1", key: "speed", value: "speed" }],
+    export: { format: "", duration: "", size: "" },
+  },
 };
 
 const openAddStepMenu = async () => {
@@ -137,6 +164,73 @@ describe("QueryBlockList", () => {
     expect(screen.getAllByLabelText("Remove sample step")).toHaveLength(2);
   });
 
+  it("renders the Transform block with its title and remove button", () => {
+    render(
+      <QueryBlockList
+        {...baseProps}
+        blockOrder={[TRANSFORM_BLOCK_ID]}
+        conditions={[]}
+        steps={[]}
+        transform={transformStep}
+      />,
+    );
+    expect(screen.getByText("Transform (ReductROS)")).toBeTruthy();
+    expect(screen.getByLabelText("Remove transform")).toBeTruthy();
+  });
+
+  it("calls onRemoveTransformBlock from the Transform block's remove button", () => {
+    const onRemoveTransformBlock = vi.fn();
+    render(
+      <QueryBlockList
+        {...baseProps}
+        blockOrder={[TRANSFORM_BLOCK_ID]}
+        conditions={[]}
+        steps={[]}
+        transform={transformStep}
+        onRemoveTransformBlock={onRemoveTransformBlock}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Remove transform"));
+    expect(onRemoveTransformBlock).toHaveBeenCalled();
+  });
+
+  it("offers Transform (ReductROS) in the Add step menu, and calls onAddTransformBlock when picked", async () => {
+    const onAddTransformBlock = vi.fn();
+    render(
+      <QueryBlockList
+        {...baseProps}
+        blockOrder={[]}
+        conditions={[]}
+        steps={[]}
+        onAddTransformBlock={onAddTransformBlock}
+      />,
+    );
+    await openAddStepMenu();
+    expect(
+      screen.getByRole("menuitem", { name: "Transform (ReductROS)" }),
+    ).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(screen.getByText("Transform (ReductROS)"));
+    });
+    expect(onAddTransformBlock).toHaveBeenCalled();
+  });
+
+  it("removes Transform (ReductROS) from the menu once it's already added", async () => {
+    render(
+      <QueryBlockList
+        {...baseProps}
+        blockOrder={[TRANSFORM_BLOCK_ID]}
+        conditions={[]}
+        steps={[]}
+        transform={transformStep}
+      />,
+    );
+    await openAddStepMenu();
+    expect(
+      screen.queryByRole("menuitem", { name: "Transform (ReductROS)" }),
+    ).toBeNull();
+  });
+
   it("hides every block until a data source is selected, but keeps Add step reachable", () => {
     render(
       <QueryBlockList
@@ -167,7 +261,7 @@ describe("QueryBlockList", () => {
     expect(onRemoveStep).toHaveBeenCalledWith("limit-1");
   });
 
-  it("offers Where labels, both Sample kinds, and Limit in the Add step menu when none has been added yet", async () => {
+  it("offers Where labels, both Sample kinds, Limit, and Transform in the Add step menu when none has been added yet", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -185,6 +279,9 @@ describe("QueryBlockList", () => {
       screen.getByRole("menuitem", { name: "Sample every N records" }),
     ).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Limit" })).toBeTruthy();
+    expect(
+      screen.getByRole("menuitem", { name: "Transform (ReductROS)" }),
+    ).toBeTruthy();
   });
 
   it("only offers the missing Sample kind in the menu when one has already been added", async () => {
@@ -294,9 +391,16 @@ describe("QueryBlockList", () => {
     render(
       <QueryBlockList
         {...baseProps}
-        blockOrder={["conditions", "each-n-1", "each-t-1", "limit-1"]}
+        blockOrder={[
+          "conditions",
+          "each-n-1",
+          "each-t-1",
+          "limit-1",
+          TRANSFORM_BLOCK_ID,
+        ]}
         conditions={[condition("a")]}
         steps={[eachNStep, eachTStep, limitStep]}
+        transform={transformStep}
       />,
     );
     expect(screen.getByLabelText("Add step")).toBeDisabled();

--- a/src/Components/QueryConditionBuilder/QueryBlockList.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryBlockList.test.tsx
@@ -115,11 +115,11 @@ describe("QueryBlockList", () => {
         steps={[]}
       />,
     );
-    expect(screen.queryByText("Where labels")).toBeNull();
+    expect(screen.queryByText("Label filter")).toBeNull();
     expect(screen.queryByLabelText("Drag to reorder")).toBeNull();
   });
 
-  it("renders the Where labels block with a drag handle and a remove button once added", () => {
+  it("renders the Label filter block with a drag handle and a remove button once added", () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -128,12 +128,12 @@ describe("QueryBlockList", () => {
         steps={[]}
       />,
     );
-    expect(screen.getByText("Where labels")).toBeTruthy();
+    expect(screen.getByText("Label filter")).toBeTruthy();
     expect(screen.getAllByLabelText("Drag to reorder")).toHaveLength(1);
-    expect(screen.getByLabelText("Remove where labels")).toBeTruthy();
+    expect(screen.getByLabelText("Remove label filter")).toBeTruthy();
   });
 
-  it("calls onRemoveConditionsBlock from the Where labels block's remove button", () => {
+  it("calls onRemoveConditionsBlock from the Label filter block's remove button", () => {
     const onRemoveConditionsBlock = vi.fn();
     render(
       <QueryBlockList
@@ -144,7 +144,7 @@ describe("QueryBlockList", () => {
         onRemoveConditionsBlock={onRemoveConditionsBlock}
       />,
     );
-    fireEvent.click(screen.getByLabelText("Remove where labels"));
+    fireEvent.click(screen.getByLabelText("Remove label filter"));
     expect(onRemoveConditionsBlock).toHaveBeenCalled();
   });
 
@@ -157,8 +157,8 @@ describe("QueryBlockList", () => {
         steps={[eachNStep, eachTStep, limitStep]}
       />,
     );
-    expect(screen.getByText("Sample every N records")).toBeTruthy();
-    expect(screen.getByText("Sample by time interval")).toBeTruthy();
+    expect(screen.getByText("Sample every N")).toBeTruthy();
+    expect(screen.getByText("Sample by time")).toBeTruthy();
     expect(screen.getByText("Limit")).toBeTruthy();
     expect(screen.getAllByLabelText("Drag to reorder")).toHaveLength(4);
     expect(screen.getAllByLabelText("Remove sample step")).toHaveLength(2);
@@ -241,8 +241,8 @@ describe("QueryBlockList", () => {
         sourceReady={false}
       />,
     );
-    expect(screen.queryByText("Where labels")).toBeNull();
-    expect(screen.queryByText("Sample by time interval")).toBeNull();
+    expect(screen.queryByText("Label filter")).toBeNull();
+    expect(screen.queryByText("Sample by time")).toBeNull();
     expect(screen.getByLabelText("Add step")).toBeDisabled();
   });
 
@@ -261,7 +261,7 @@ describe("QueryBlockList", () => {
     expect(onRemoveStep).toHaveBeenCalledWith("limit-1");
   });
 
-  it("offers Where labels, both Sample kinds, Limit, and Transform in the Add step menu when none has been added yet", async () => {
+  it("offers Label filter, both Sample kinds, Limit, and Transform in the Add step menu when none has been added yet", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -271,12 +271,12 @@ describe("QueryBlockList", () => {
       />,
     );
     await openAddStepMenu();
-    expect(screen.getByRole("menuitem", { name: "Where labels" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Label filter" })).toBeTruthy();
     expect(
-      screen.getByRole("menuitem", { name: "Sample by time interval" }),
+      screen.getByRole("menuitem", { name: "Sample by time" }),
     ).toBeTruthy();
     expect(
-      screen.getByRole("menuitem", { name: "Sample every N records" }),
+      screen.getByRole("menuitem", { name: "Sample every N" }),
     ).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Limit" })).toBeTruthy();
     expect(
@@ -295,10 +295,10 @@ describe("QueryBlockList", () => {
     );
     await openAddStepMenu();
     expect(
-      screen.queryByRole("menuitem", { name: "Sample by time interval" }),
+      screen.queryByRole("menuitem", { name: "Sample by time" }),
     ).toBeNull();
     expect(
-      screen.getByRole("menuitem", { name: "Sample every N records" }),
+      screen.getByRole("menuitem", { name: "Sample every N" }),
     ).toBeTruthy();
   });
 
@@ -313,14 +313,14 @@ describe("QueryBlockList", () => {
     );
     await openAddStepMenu();
     expect(
-      screen.queryByRole("menuitem", { name: "Sample by time interval" }),
+      screen.queryByRole("menuitem", { name: "Sample by time" }),
     ).toBeNull();
     expect(
-      screen.queryByRole("menuitem", { name: "Sample every N records" }),
+      screen.queryByRole("menuitem", { name: "Sample every N" }),
     ).toBeNull();
   });
 
-  it("removes Where labels from the menu once it's already added", async () => {
+  it("removes Label filter from the menu once it's already added", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -330,10 +330,10 @@ describe("QueryBlockList", () => {
       />,
     );
     await openAddStepMenu();
-    expect(screen.queryByRole("menuitem", { name: "Where labels" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Label filter" })).toBeNull();
   });
 
-  it("calls onAddConditionsBlock when Where labels is picked from the menu", async () => {
+  it("calls onAddConditionsBlock when Label filter is picked from the menu", async () => {
     const onAddConditionsBlock = vi.fn();
     render(
       <QueryBlockList
@@ -346,12 +346,12 @@ describe("QueryBlockList", () => {
     );
     await openAddStepMenu();
     await act(async () => {
-      fireEvent.click(screen.getByText("Where labels"));
+      fireEvent.click(screen.getByText("Label filter"));
     });
     expect(onAddConditionsBlock).toHaveBeenCalled();
   });
 
-  it("calls onAddEachT when Sample by time interval is picked from the menu", async () => {
+  it("calls onAddEachT when Sample by time is picked from the menu", async () => {
     const onAddEachT = vi.fn();
     render(
       <QueryBlockList
@@ -364,12 +364,12 @@ describe("QueryBlockList", () => {
     );
     await openAddStepMenu();
     await act(async () => {
-      fireEvent.click(screen.getByText("Sample by time interval"));
+      fireEvent.click(screen.getByText("Sample by time"));
     });
     expect(onAddEachT).toHaveBeenCalled();
   });
 
-  it("calls onAddEachN when Sample every N records is picked from the menu", async () => {
+  it("calls onAddEachN when Sample every N is picked from the menu", async () => {
     const onAddEachN = vi.fn();
     render(
       <QueryBlockList
@@ -382,7 +382,7 @@ describe("QueryBlockList", () => {
     );
     await openAddStepMenu();
     await act(async () => {
-      fireEvent.click(screen.getByText("Sample every N records"));
+      fireEvent.click(screen.getByText("Sample every N"));
     });
     expect(onAddEachN).toHaveBeenCalled();
   });

--- a/src/Components/QueryConditionBuilder/QueryBlockList.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryBlockList.test.tsx
@@ -174,8 +174,8 @@ describe("QueryBlockList", () => {
         transform={transformStep}
       />,
     );
-    expect(screen.getByText("Transform (ReductROS)")).toBeTruthy();
-    expect(screen.getByLabelText("Remove transform")).toBeTruthy();
+    expect(screen.getByText("Process (ROS)")).toBeTruthy();
+    expect(screen.getByLabelText("Remove process")).toBeTruthy();
   });
 
   it("calls onRemoveTransformBlock from the Transform block's remove button", () => {
@@ -190,11 +190,11 @@ describe("QueryBlockList", () => {
         onRemoveTransformBlock={onRemoveTransformBlock}
       />,
     );
-    fireEvent.click(screen.getByLabelText("Remove transform"));
+    fireEvent.click(screen.getByLabelText("Remove process"));
     expect(onRemoveTransformBlock).toHaveBeenCalled();
   });
 
-  it("offers Transform (ReductROS) in the Add step menu, and calls onAddTransformBlock when picked", async () => {
+  it("offers Process (ROS) in the Add step menu, and calls onAddTransformBlock when picked", async () => {
     const onAddTransformBlock = vi.fn();
     render(
       <QueryBlockList
@@ -207,15 +207,15 @@ describe("QueryBlockList", () => {
     );
     await openAddStepMenu();
     expect(
-      screen.getByRole("menuitem", { name: "Transform (ReductROS)" }),
+      screen.getByRole("menuitem", { name: "Process (ROS)" }),
     ).toBeTruthy();
     await act(async () => {
-      fireEvent.click(screen.getByText("Transform (ReductROS)"));
+      fireEvent.click(screen.getByText("Process (ROS)"));
     });
     expect(onAddTransformBlock).toHaveBeenCalled();
   });
 
-  it("removes Transform (ReductROS) from the menu once it's already added", async () => {
+  it("removes Process (ROS) from the menu once it's already added", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -227,7 +227,7 @@ describe("QueryBlockList", () => {
     );
     await openAddStepMenu();
     expect(
-      screen.queryByRole("menuitem", { name: "Transform (ReductROS)" }),
+      screen.queryByRole("menuitem", { name: "Process (ROS)" }),
     ).toBeNull();
   });
 
@@ -280,7 +280,7 @@ describe("QueryBlockList", () => {
     ).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Limit" })).toBeTruthy();
     expect(
-      screen.getByRole("menuitem", { name: "Transform (ReductROS)" }),
+      screen.getByRole("menuitem", { name: "Process (ROS)" }),
     ).toBeTruthy();
   });
 

--- a/src/Components/QueryConditionBuilder/QueryBlockList.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryBlockList.test.tsx
@@ -215,7 +215,7 @@ describe("QueryBlockList", () => {
     expect(onAddTransformBlock).toHaveBeenCalled();
   });
 
-  it("removes Process (ROS) from the menu once it's already added", async () => {
+  it("greys out Process (ROS) once it's already added", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -227,11 +227,11 @@ describe("QueryBlockList", () => {
     );
     await openAddStepMenu();
     expect(
-      screen.queryByRole("menuitem", { name: "Process (ROS)" }),
-    ).toBeNull();
+      screen.getByRole("menuitem", { name: "Process (ROS)" }),
+    ).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("hides every block until a data source is selected, but keeps Add step reachable", () => {
+  it("hides every block until a data source is selected, but keeps Add step reachable and greys out its menu", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -243,7 +243,11 @@ describe("QueryBlockList", () => {
     );
     expect(screen.queryByText("Label filter")).toBeNull();
     expect(screen.queryByText("Sample by time")).toBeNull();
-    expect(screen.getByLabelText("Add step")).toBeDisabled();
+    expect(screen.getByLabelText("Add step")).not.toBeDisabled();
+    await openAddStepMenu();
+    expect(
+      screen.getByRole("menuitem", { name: "Label filter" }),
+    ).toHaveAttribute("aria-disabled", "true");
   });
 
   it("calls onRemoveStep with a step's id from its block's remove button", () => {
@@ -284,7 +288,7 @@ describe("QueryBlockList", () => {
     ).toBeTruthy();
   });
 
-  it("only offers the missing Sample kind in the menu when one has already been added", async () => {
+  it("greys out only the Sample kind that's already been added", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -295,14 +299,14 @@ describe("QueryBlockList", () => {
     );
     await openAddStepMenu();
     expect(
-      screen.queryByRole("menuitem", { name: "Sample by time" }),
-    ).toBeNull();
+      screen.getByRole("menuitem", { name: "Sample by time" }),
+    ).toHaveAttribute("aria-disabled", "true");
     expect(
       screen.getByRole("menuitem", { name: "Sample every N" }),
-    ).toBeTruthy();
+    ).not.toHaveAttribute("aria-disabled", "true");
   });
 
-  it("removes both Sample menu items once both kinds are already added", async () => {
+  it("greys out both Sample menu items once both kinds are already added", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -313,14 +317,14 @@ describe("QueryBlockList", () => {
     );
     await openAddStepMenu();
     expect(
-      screen.queryByRole("menuitem", { name: "Sample by time" }),
-    ).toBeNull();
+      screen.getByRole("menuitem", { name: "Sample by time" }),
+    ).toHaveAttribute("aria-disabled", "true");
     expect(
-      screen.queryByRole("menuitem", { name: "Sample every N" }),
-    ).toBeNull();
+      screen.getByRole("menuitem", { name: "Sample every N" }),
+    ).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("removes Label filter from the menu once it's already added", async () => {
+  it("greys out Label filter once it's already added", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -330,7 +334,9 @@ describe("QueryBlockList", () => {
       />,
     );
     await openAddStepMenu();
-    expect(screen.queryByRole("menuitem", { name: "Label filter" })).toBeNull();
+    expect(
+      screen.getByRole("menuitem", { name: "Label filter" }),
+    ).toHaveAttribute("aria-disabled", "true");
   });
 
   it("calls onAddConditionsBlock when Label filter is picked from the menu", async () => {
@@ -387,7 +393,7 @@ describe("QueryBlockList", () => {
     expect(onAddEachN).toHaveBeenCalled();
   });
 
-  it("disables Add step only once every block type is present", () => {
+  it("keeps Add step enabled and greys out every item once every block type is present", async () => {
     render(
       <QueryBlockList
         {...baseProps}
@@ -403,7 +409,20 @@ describe("QueryBlockList", () => {
         transform={transformStep}
       />,
     );
-    expect(screen.getByLabelText("Add step")).toBeDisabled();
+    expect(screen.getByLabelText("Add step")).not.toBeDisabled();
+    await openAddStepMenu();
+    for (const name of [
+      "Label filter",
+      "Sample by time",
+      "Sample every N",
+      "Limit",
+      "Process (ROS)",
+    ]) {
+      expect(screen.getByRole("menuitem", { name })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+    }
   });
 
   it("keeps Add step enabled when only some block types are present", () => {

--- a/src/Components/QueryConditionBuilder/QueryBlockList.tsx
+++ b/src/Components/QueryConditionBuilder/QueryBlockList.tsx
@@ -133,7 +133,7 @@ export default function QueryBlockList({
     !hasEachT && { key: "sample_each_t", label: "Sample by time interval" },
     !hasEachN && { key: "sample_each_n", label: "Sample every N records" },
     !hasLimit && { key: "limit", label: "Limit" },
-    !hasTransform && { key: "transform_ros", label: "Transform (ReductROS)" },
+    !hasTransform && { key: "transform_ros", label: "Process (ROS)" },
   ].filter((item) => item !== false);
 
   const handleMenuClick = ({ key }: { key: string }) => {
@@ -196,8 +196,8 @@ export default function QueryBlockList({
               <SortableCard
                 key={TRANSFORM_BLOCK_ID}
                 id={TRANSFORM_BLOCK_ID}
-                label="Transform (ReductROS)"
-                removeLabel="Remove transform"
+                label="Process (ROS)"
+                removeLabel="Remove process"
                 onRemove={onRemoveTransformBlock}
               >
                 <TransformStepEditor

--- a/src/Components/QueryConditionBuilder/QueryBlockList.tsx
+++ b/src/Components/QueryConditionBuilder/QueryBlockList.tsx
@@ -3,6 +3,7 @@ import { PlusOutlined } from "@ant-design/icons";
 import ConditionListEditor from "./ConditionListEditor";
 import SampleStepEditor from "./SampleStepEditor";
 import LimitStepEditor from "./LimitStepEditor";
+import TransformStepEditor from "./TransformStepEditor";
 import SortableCard from "./SortableCard";
 import SortableList from "./SortableList";
 import {
@@ -13,15 +14,28 @@ import {
   EachTStep,
   LimitStep,
 } from "../../Helpers/conditionalQueryBuilder";
+import {
+  KeyValueRow,
+  RosExportConfig,
+  RosSection,
+  TransformStepEntry,
+  TRANSFORM_BLOCK_ID,
+} from "../../Helpers/transformStepBuilder";
 
 type Block =
   | { id: typeof CONDITIONS_BLOCK_ID; kind: "conditions" }
+  | {
+      id: typeof TRANSFORM_BLOCK_ID;
+      kind: "transform";
+      transform: TransformStepEntry;
+    }
   | { id: string; kind: "step"; step: Step };
 
 interface QueryBlockListProps {
   blockOrder: string[];
   conditions: FlatCondition[];
   steps: Step[];
+  transform?: TransformStepEntry;
   sourceReady?: boolean;
   labelOptions?: string[];
   intervalValue?: string;
@@ -44,6 +58,24 @@ interface QueryBlockListProps {
   onAddLimit: () => void;
   onAddConditionsBlock: () => void;
   onRemoveConditionsBlock: () => void;
+  onAddTransformBlock: () => void;
+  onRemoveTransformBlock: () => void;
+  onAddSection: (section: RosSection) => void;
+  onRemoveSection: (section: RosSection) => void;
+  onChangeTopic: (topic: string) => void;
+  onAddEncodeRow: () => void;
+  onChangeEncodeRow: (
+    id: string,
+    changes: Partial<Pick<KeyValueRow, "key" | "value">>,
+  ) => void;
+  onRemoveEncodeRow: (id: string) => void;
+  onAddAsLabelRow: () => void;
+  onChangeAsLabelRow: (
+    id: string,
+    changes: Partial<Pick<KeyValueRow, "key" | "value">>,
+  ) => void;
+  onRemoveAsLabelRow: (id: string) => void;
+  onChangeExport: (changes: Partial<RosExportConfig>) => void;
   onRemoveStep: (id: string) => void;
   onReorderBlock: (fromIndex: number, toIndex: number) => void;
 }
@@ -52,6 +84,7 @@ export default function QueryBlockList({
   blockOrder,
   conditions,
   steps,
+  transform,
   sourceReady = true,
   labelOptions,
   intervalValue,
@@ -66,6 +99,18 @@ export default function QueryBlockList({
   onAddLimit,
   onAddConditionsBlock,
   onRemoveConditionsBlock,
+  onAddTransformBlock,
+  onRemoveTransformBlock,
+  onAddSection,
+  onRemoveSection,
+  onChangeTopic,
+  onAddEncodeRow,
+  onChangeEncodeRow,
+  onRemoveEncodeRow,
+  onAddAsLabelRow,
+  onChangeAsLabelRow,
+  onRemoveAsLabelRow,
+  onChangeExport,
   onRemoveStep,
   onReorderBlock,
 }: QueryBlockListProps) {
@@ -73,7 +118,9 @@ export default function QueryBlockList({
   const hasEachN = steps.some((step) => step.type === "each_n");
   const hasEachT = steps.some((step) => step.type === "each_t");
   const hasLimit = steps.some((step) => step.type === "limit");
-  const allAdded = hasConditionsBlock && hasEachN && hasEachT && hasLimit;
+  const hasTransform = !!transform;
+  const allAdded =
+    hasConditionsBlock && hasEachN && hasEachT && hasLimit && hasTransform;
   const addStepHint = !sourceReady
     ? "Select a bucket and entries first"
     : allAdded
@@ -86,6 +133,7 @@ export default function QueryBlockList({
     !hasEachT && { key: "sample_each_t", label: "Sample by time interval" },
     !hasEachN && { key: "sample_each_n", label: "Sample every N records" },
     !hasLimit && { key: "limit", label: "Limit" },
+    !hasTransform && { key: "transform_ros", label: "Transform (ReductROS)" },
   ].filter((item) => item !== false);
 
   const handleMenuClick = ({ key }: { key: string }) => {
@@ -97,6 +145,8 @@ export default function QueryBlockList({
       onAddEachN();
     } else if (key === "limit") {
       onAddLimit();
+    } else if (key === "transform_ros") {
+      onAddTransformBlock();
     }
   };
 
@@ -104,6 +154,11 @@ export default function QueryBlockList({
     ? blockOrder.flatMap((id): Block[] => {
         if (id === CONDITIONS_BLOCK_ID) {
           return [{ id: CONDITIONS_BLOCK_ID, kind: "conditions" }];
+        }
+        if (id === TRANSFORM_BLOCK_ID) {
+          return transform
+            ? [{ id: TRANSFORM_BLOCK_ID, kind: "transform", transform }]
+            : [];
         }
         const step = steps.find((s) => s.id === id);
         return step ? [{ id, kind: "step", step }] : [];
@@ -132,6 +187,31 @@ export default function QueryBlockList({
                   onChangeCondition={onChangeCondition}
                   onRemoveCondition={onRemoveCondition}
                   onAddCondition={onAddCondition}
+                />
+              </SortableCard>
+            );
+          }
+          if (block.kind === "transform") {
+            return (
+              <SortableCard
+                key={TRANSFORM_BLOCK_ID}
+                id={TRANSFORM_BLOCK_ID}
+                label="Transform (ReductROS)"
+                removeLabel="Remove transform"
+                onRemove={onRemoveTransformBlock}
+              >
+                <TransformStepEditor
+                  step={block.transform.ros}
+                  onAddSection={onAddSection}
+                  onRemoveSection={onRemoveSection}
+                  onChangeTopic={onChangeTopic}
+                  onAddEncodeRow={onAddEncodeRow}
+                  onChangeEncodeRow={onChangeEncodeRow}
+                  onRemoveEncodeRow={onRemoveEncodeRow}
+                  onAddAsLabelRow={onAddAsLabelRow}
+                  onChangeAsLabelRow={onChangeAsLabelRow}
+                  onRemoveAsLabelRow={onRemoveAsLabelRow}
+                  onChangeExport={onChangeExport}
                 />
               </SortableCard>
             );

--- a/src/Components/QueryConditionBuilder/QueryBlockList.tsx
+++ b/src/Components/QueryConditionBuilder/QueryBlockList.tsx
@@ -174,20 +174,28 @@ export default function QueryBlockList({
     }
   };
 
-  const blocks: Block[] = sourceReady
-    ? blockOrder.flatMap((id): Block[] => {
-        if (id === CONDITIONS_BLOCK_ID) {
-          return [{ id: CONDITIONS_BLOCK_ID, kind: "conditions" }];
-        }
-        if (id === TRANSFORM_BLOCK_ID) {
-          return transform
-            ? [{ id: TRANSFORM_BLOCK_ID, kind: "transform", transform }]
-            : [];
-        }
-        const step = steps.find((s) => s.id === id);
-        return step ? [{ id, kind: "step", step }] : [];
-      })
-    : [];
+  const blocks: Block[] = blockOrder.flatMap((id): Block[] => {
+    if (id === CONDITIONS_BLOCK_ID) {
+      return sourceReady
+        ? [{ id: CONDITIONS_BLOCK_ID, kind: "conditions" }]
+        : [];
+    }
+    if (id === TRANSFORM_BLOCK_ID) {
+      return sourceReady && transform
+        ? [{ id: TRANSFORM_BLOCK_ID, kind: "transform", transform }]
+        : [];
+    }
+    const step = steps.find((s) => s.id === id);
+    if (!step) return [];
+    // The each_t/interval step is the app's built-in default (present even
+    // before a bucket/entry is picked), so it stays visible regardless of
+    // sourceReady - every other step is only ever added once a source is
+    // selected, so those still wait on it.
+    if (step.type === "each_t" || sourceReady) {
+      return [{ id, kind: "step", step }];
+    }
+    return [];
+  });
 
   return (
     <div>

--- a/src/Components/QueryConditionBuilder/QueryBlockList.tsx
+++ b/src/Components/QueryConditionBuilder/QueryBlockList.tsx
@@ -50,6 +50,7 @@ interface QueryBlockListProps {
   ) => void;
   onRemoveCondition: (id: string) => void;
   onAddCondition: () => void;
+
   onChangeEachN: (id: string, changes: Partial<EachNStep>) => void;
   onChangeEachT: (id: string, changes: Partial<EachTStep>) => void;
   onChangeLimit: (id: string, changes: Partial<LimitStep>) => void;
@@ -129,9 +130,9 @@ export default function QueryBlockList({
   const disabled = !sourceReady || allAdded;
 
   const menuItems = [
-    !hasConditionsBlock && { key: "conditions", label: "Where labels" },
-    !hasEachT && { key: "sample_each_t", label: "Sample by time interval" },
-    !hasEachN && { key: "sample_each_n", label: "Sample every N records" },
+    !hasConditionsBlock && { key: "conditions", label: "Label filter" },
+    !hasEachT && { key: "sample_each_t", label: "Sample by time" },
+    !hasEachN && { key: "sample_each_n", label: "Sample every N" },
     !hasLimit && { key: "limit", label: "Limit" },
     !hasTransform && { key: "transform_ros", label: "Process (ROS)" },
   ].filter((item) => item !== false);
@@ -176,8 +177,8 @@ export default function QueryBlockList({
               <SortableCard
                 key={CONDITIONS_BLOCK_ID}
                 id={CONDITIONS_BLOCK_ID}
-                label="Where labels"
-                removeLabel="Remove where labels"
+                label="Label filter"
+                removeLabel="Remove label filter"
                 onRemove={onRemoveConditionsBlock}
               >
                 <ConditionListEditor
@@ -223,13 +224,10 @@ export default function QueryBlockList({
                 key={step.id}
                 id={step.id}
                 label={
-                  step.type === "each_n"
-                    ? "Sample every N records"
-                    : "Sample by time interval"
+                  step.type === "each_n" ? "Sample every N" : "Sample by time"
                 }
                 removeLabel="Remove sample step"
                 onRemove={() => onRemoveStep(step.id)}
-                inline
               >
                 <SampleStepEditor
                   kind={step.type}
@@ -254,7 +252,6 @@ export default function QueryBlockList({
               label="Limit"
               removeLabel="Remove limit step"
               onRemove={() => onRemoveStep(step.id)}
-              inline
             >
               <LimitStepEditor
                 step={step.limit}

--- a/src/Components/QueryConditionBuilder/QueryBlockList.tsx
+++ b/src/Components/QueryConditionBuilder/QueryBlockList.tsx
@@ -120,22 +120,45 @@ export default function QueryBlockList({
   const hasEachT = steps.some((step) => step.type === "each_t");
   const hasLimit = steps.some((step) => step.type === "limit");
   const hasTransform = !!transform;
-  const allAdded =
-    hasConditionsBlock && hasEachN && hasEachT && hasLimit && hasTransform;
-  const addStepHint = !sourceReady
-    ? "Select a bucket and entries first"
-    : allAdded
-      ? "All steps are already added"
-      : "";
-  const disabled = !sourceReady || allAdded;
 
-  const menuItems = [
-    !hasConditionsBlock && { key: "conditions", label: "Label filter" },
-    !hasEachT && { key: "sample_each_t", label: "Sample by time" },
-    !hasEachN && { key: "sample_each_n", label: "Sample every N" },
-    !hasLimit && { key: "limit", label: "Limit" },
-    !hasTransform && { key: "transform_ros", label: "Process (ROS)" },
-  ].filter((item) => item !== false);
+  const STEP_LABELS: Record<string, string> = {
+    conditions: "Label filter",
+    sample_each_t: "Sample by time",
+    sample_each_n: "Sample every N",
+    limit: "Limit",
+    transform_ros: "Process (ROS)",
+  };
+
+  const disabledStepReason = (key: string): string | undefined => {
+    if (!sourceReady) return "Select a bucket and entries first";
+    if (key === "conditions" && hasConditionsBlock)
+      return "Label filter is already added";
+    if (key === "sample_each_t" && hasEachT)
+      return "Sample by time is already added";
+    if (key === "sample_each_n" && hasEachN)
+      return "Sample every N is already added";
+    if (key === "limit" && hasLimit) return "Limit is already added";
+    if (key === "transform_ros" && hasTransform)
+      return "Process (ROS) is already added";
+    return undefined;
+  };
+
+  const menuItems = Object.keys(STEP_LABELS).map((key) => {
+    const reason = disabledStepReason(key);
+    return {
+      key,
+      disabled: !!reason,
+      label: reason ? (
+        <Tooltip title={reason} placement="right">
+          <span style={{ color: "rgba(0, 0, 0, 0.25)" }}>
+            {STEP_LABELS[key]}
+          </span>
+        </Tooltip>
+      ) : (
+        STEP_LABELS[key]
+      ),
+    };
+  });
 
   const handleMenuClick = ({ key }: { key: string }) => {
     if (key === "conditions") {
@@ -262,26 +285,19 @@ export default function QueryBlockList({
         }}
       />
 
-      <Tooltip title={addStepHint}>
-        {/* A disabled Button doesn't receive pointer events, so wrapping it
-            directly stops the Tooltip's hover trigger from ever firing -
-            this extra span still does. */}
-        <span style={{ display: "inline-block", marginTop: 8 }}>
-          <Dropdown
-            menu={{ items: menuItems, onClick: handleMenuClick }}
-            trigger={["click"]}
-            disabled={disabled}
+      <span style={{ display: "inline-block", marginTop: 8 }}>
+        <Dropdown
+          menu={{ items: menuItems, onClick: handleMenuClick }}
+          trigger={["click"]}
+        >
+          <Button
+            aria-label="Add step"
+            icon={<PlusOutlined style={{ transform: "scale(0.65)" }} />}
           >
-            <Button
-              aria-label="Add step"
-              disabled={disabled}
-              icon={<PlusOutlined style={{ transform: "scale(0.65)" }} />}
-            >
-              Add step
-            </Button>
-          </Dropdown>
-        </span>
-      </Tooltip>
+            Add step
+          </Button>
+        </Dropdown>
+      </span>
     </div>
   );
 }

--- a/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
@@ -1053,7 +1053,7 @@ describe("QueryConditionBuilder", () => {
     };
 
     const addSection = async (
-      name: "Filter" | "Encode" | "Label" | "Export",
+      name: "Filter" | "Encode" | "As label" | "Export",
     ) => {
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Add option"));
@@ -1095,6 +1095,29 @@ describe("QueryConditionBuilder", () => {
       expect(screen.queryByLabelText("Add option")).toBeNull();
     });
 
+    it("offers Process (ROS) again in the Add step menu after it's removed, and drops #ext from onChange", async () => {
+      const onChange = vi.fn();
+      render(
+        <QueryConditionBuilder
+          value=""
+          onChange={onChange}
+          mode="builder"
+          onUnrepresentable={noop}
+          validationContext={readyValidationContext}
+        />,
+      );
+      await addTransformBlock();
+      fireEvent.click(screen.getByLabelText("Remove process"));
+
+      const [lastCall] = onChange.mock.calls.at(-1) as [string];
+      expect(JSON.parse(lastCall)).not.toHaveProperty("#ext");
+
+      await openAddStepMenu();
+      expect(
+        screen.getByRole("menuitem", { name: "Process (ROS)" }),
+      ).toBeTruthy();
+    });
+
     it("reports a typed topic and as_label mapping through onChange, merged as a #ext key", async () => {
       const onChange = vi.fn();
       render(
@@ -1112,7 +1135,7 @@ describe("QueryConditionBuilder", () => {
         screen.getByPlaceholderText("optional ROS topic filter"),
         { target: { value: "/robot/odom" } },
       );
-      await addSection("Label");
+      await addSection("As label");
       fireEvent.change(
         screen.getByPlaceholderText("label name (e.g. label_name)"),
         { target: { value: "speed" } },

--- a/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
@@ -70,14 +70,14 @@ const readyValidationContext = {
   entry: "testEntry",
 };
 
-// Where labels is a step like Sample/Limit - added on demand from the
+// Label filter is a step like Sample/Limit - added on demand from the
 // "+ Add step" menu rather than shown by default.
 const addWhereLabels = async () => {
   await act(async () => {
     fireEvent.click(screen.getByLabelText("Add step"));
   });
   await act(async () => {
-    fireEvent.click(screen.getByText("Where labels"));
+    fireEvent.click(screen.getByText("Label filter"));
   });
 };
 
@@ -93,11 +93,11 @@ describe("QueryConditionBuilder", () => {
       />,
     );
     expect(screen.getByText("Query")).toBeTruthy();
-    expect(screen.queryByText("Where labels")).toBeNull();
+    expect(screen.queryByText("Label filter")).toBeNull();
     expect(screen.queryByPlaceholderText("value")).toBeNull();
   });
 
-  it("reveals one empty condition row once Where labels is added from the menu", async () => {
+  it("reveals one empty condition row once Label filter is added from the menu", async () => {
     render(
       <QueryConditionBuilder
         value=""
@@ -108,7 +108,7 @@ describe("QueryConditionBuilder", () => {
       />,
     );
     await addWhereLabels();
-    expect(screen.getByLabelText("Remove where labels")).toBeTruthy();
+    expect(screen.getByLabelText("Remove label filter")).toBeTruthy();
     expect(screen.getByPlaceholderText("value")).toBeTruthy();
   });
 
@@ -165,7 +165,7 @@ describe("QueryConditionBuilder", () => {
       />,
     );
 
-    const [labelInput] = screen.getAllByRole("combobox");
+    const labelInput = screen.getByRole("combobox", { name: "Label" });
     expect(labelInput).toHaveValue("method");
     expect(screen.getByPlaceholderText("value")).toHaveValue("GET");
   });
@@ -205,7 +205,7 @@ describe("QueryConditionBuilder", () => {
       />,
     );
     await addWhereLabels();
-    const [labelInput] = screen.getAllByRole("combobox");
+    const labelInput = screen.getByRole("combobox", { name: "Label" });
     fireEvent.change(labelInput, { target: { value: "status" } });
     fireEvent.change(screen.getByPlaceholderText("value"), {
       target: { value: "active" },
@@ -227,7 +227,7 @@ describe("QueryConditionBuilder", () => {
         validationContext={readyValidationContext}
       />,
     );
-    const [labelInput] = screen.getAllByRole("combobox");
+    const labelInput = screen.getByRole("combobox", { name: "Label" });
     expect(labelInput).toHaveValue("status");
     expect(screen.getByPlaceholderText("value")).toHaveValue("active");
   });
@@ -244,7 +244,7 @@ describe("QueryConditionBuilder", () => {
       />,
     );
     await addWhereLabels();
-    const [labelInput] = screen.getAllByRole("combobox");
+    const labelInput = screen.getByRole("combobox", { name: "Label" });
     fireEvent.change(labelInput, { target: { value: "status" } });
     fireEvent.change(screen.getByPlaceholderText("value"), {
       target: { value: "active" },
@@ -292,7 +292,7 @@ describe("QueryConditionBuilder", () => {
     );
 
     await addWhereLabels();
-    const [labelInput] = screen.getAllByRole("combobox");
+    const labelInput = screen.getByRole("combobox", { name: "Label" });
     fireEvent.mouseDown(labelInput);
     expect(await screen.findByTitle("status")).toBeTruthy();
     expect(screen.getByTitle("method")).toBeTruthy();
@@ -339,7 +339,7 @@ describe("QueryConditionBuilder", () => {
       />,
     );
     await addWhereLabels();
-    const [labelInput] = screen.getAllByRole("combobox");
+    const labelInput = screen.getByRole("combobox", { name: "Label" });
     fireEvent.change(labelInput, { target: { value: "status" } });
     // The "+" button stays disabled until the row it would chain off of has
     // both a label and a value.
@@ -381,7 +381,7 @@ describe("QueryConditionBuilder", () => {
     await addWhereLabels();
     // The "+" button stays disabled until row 1 has both a label and a
     // value.
-    const [labelInput] = screen.getAllByRole("combobox");
+    const labelInput = screen.getByRole("combobox", { name: "Label" });
     fireEvent.change(labelInput, { target: { value: "status" } });
     fireEvent.change(screen.getByPlaceholderText("value"), {
       target: { value: "active" },
@@ -466,7 +466,7 @@ describe("QueryConditionBuilder", () => {
     // partially filled one is.
     expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(false);
 
-    const [labelInput] = screen.getAllByRole("combobox");
+    const labelInput = screen.getByRole("combobox", { name: "Label" });
     fireEvent.change(labelInput, { target: { value: "status" } });
     expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(true);
 
@@ -510,9 +510,9 @@ describe("QueryConditionBuilder", () => {
       );
       await openAddStepMenu();
       await act(async () => {
-        fireEvent.click(screen.getByRole("menuitem", { name: "Where labels" }));
+        fireEvent.click(screen.getByRole("menuitem", { name: "Label filter" }));
       });
-      const [labelInput] = screen.getAllByRole("combobox");
+      const labelInput = screen.getByRole("combobox", { name: "Label" });
       fireEvent.change(labelInput, { target: { value: "status" } });
       fireEvent.change(screen.getByPlaceholderText("value"), {
         target: { value: "active" },
@@ -521,10 +521,10 @@ describe("QueryConditionBuilder", () => {
       await openAddStepMenu();
       await act(async () => {
         fireEvent.click(
-          screen.getByRole("menuitem", { name: "Sample by time interval" }),
+          screen.getByRole("menuitem", { name: "Sample by time" }),
         );
       });
-      fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
+      fireEvent.change(screen.getByRole("combobox", { name: "Interval" }), {
         target: { value: "30s" },
       });
 
@@ -535,7 +535,7 @@ describe("QueryConditionBuilder", () => {
       });
     });
 
-    it("adds a Sample every N records step directly and reports its count", async () => {
+    it("adds a Sample every N step directly and reports its count", async () => {
       const onChange = vi.fn();
       render(
         <QueryConditionBuilder
@@ -549,7 +549,7 @@ describe("QueryConditionBuilder", () => {
       await openAddStepMenu();
       await act(async () => {
         fireEvent.click(
-          screen.getByRole("menuitem", { name: "Sample every N records" }),
+          screen.getByRole("menuitem", { name: "Sample every N" }),
         );
       });
       fireEvent.change(screen.getByPlaceholderText("every Nth record"), {
@@ -574,17 +574,17 @@ describe("QueryConditionBuilder", () => {
       await openAddStepMenu();
       await act(async () => {
         fireEvent.click(
-          screen.getByRole("menuitem", { name: "Sample by time interval" }),
+          screen.getByRole("menuitem", { name: "Sample by time" }),
         );
       });
-      fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
+      fireEvent.change(screen.getByRole("combobox", { name: "Interval" }), {
         target: { value: "1s" },
       });
 
       await openAddStepMenu();
       await act(async () => {
         fireEvent.click(
-          screen.getByRole("menuitem", { name: "Sample every N records" }),
+          screen.getByRole("menuitem", { name: "Sample every N" }),
         );
       });
       fireEvent.change(screen.getByPlaceholderText("every Nth record"), {
@@ -611,22 +611,22 @@ describe("QueryConditionBuilder", () => {
       await openAddStepMenu();
       await act(async () => {
         fireEvent.click(
-          screen.getByRole("menuitem", { name: "Sample by time interval" }),
+          screen.getByRole("menuitem", { name: "Sample by time" }),
         );
       });
       await openAddStepMenu();
       await act(async () => {
         fireEvent.click(
-          screen.getByRole("menuitem", { name: "Sample every N records" }),
+          screen.getByRole("menuitem", { name: "Sample every N" }),
         );
       });
 
       await openAddStepMenu();
       expect(
-        screen.queryByRole("menuitem", { name: "Sample by time interval" }),
+        screen.queryByRole("menuitem", { name: "Sample by time" }),
       ).toBeNull();
       expect(
-        screen.queryByRole("menuitem", { name: "Sample every N records" }),
+        screen.queryByRole("menuitem", { name: "Sample every N" }),
       ).toBeNull();
     });
 
@@ -643,9 +643,9 @@ describe("QueryConditionBuilder", () => {
       );
       await openAddStepMenu();
       await act(async () => {
-        fireEvent.click(screen.getByRole("menuitem", { name: "Where labels" }));
+        fireEvent.click(screen.getByRole("menuitem", { name: "Label filter" }));
       });
-      const [labelInput] = screen.getAllByRole("combobox");
+      const labelInput = screen.getByRole("combobox", { name: "Label" });
       fireEvent.change(labelInput, { target: { value: "status" } });
       fireEvent.change(screen.getByPlaceholderText("value"), {
         target: { value: "active" },
@@ -679,9 +679,9 @@ describe("QueryConditionBuilder", () => {
       );
       await openAddStepMenu();
       await act(async () => {
-        fireEvent.click(screen.getByRole("menuitem", { name: "Where labels" }));
+        fireEvent.click(screen.getByRole("menuitem", { name: "Label filter" }));
       });
-      const [labelInput] = screen.getAllByRole("combobox");
+      const labelInput = screen.getByRole("combobox", { name: "Label" });
       fireEvent.change(labelInput, { target: { value: "status" } });
       fireEvent.change(screen.getByPlaceholderText("value"), {
         target: { value: "active" },
@@ -690,10 +690,10 @@ describe("QueryConditionBuilder", () => {
       await openAddStepMenu();
       await act(async () => {
         fireEvent.click(
-          screen.getByRole("menuitem", { name: "Sample by time interval" }),
+          screen.getByRole("menuitem", { name: "Sample by time" }),
         );
       });
-      fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
+      fireEvent.change(screen.getByRole("combobox", { name: "Interval" }), {
         target: { value: "30s" },
       });
       await openAddStepMenu();
@@ -729,9 +729,9 @@ describe("QueryConditionBuilder", () => {
       );
       await openAddStepMenu();
       await act(async () => {
-        fireEvent.click(screen.getByRole("menuitem", { name: "Where labels" }));
+        fireEvent.click(screen.getByRole("menuitem", { name: "Label filter" }));
       });
-      const [labelInput] = screen.getAllByRole("combobox");
+      const labelInput = screen.getByRole("combobox", { name: "Label" });
       fireEvent.change(labelInput, { target: { value: "status" } });
       fireEvent.change(screen.getByPlaceholderText("value"), {
         target: { value: "active" },
@@ -754,7 +754,7 @@ describe("QueryConditionBuilder", () => {
         "$limit",
       ]);
 
-      // Drag the Limit block above the Where labels block.
+      // Drag the Limit block above the Label filter block.
       act(() => {
         capturedOnDragEnd?.({
           active: { id: limitStepId },
@@ -781,9 +781,9 @@ describe("QueryConditionBuilder", () => {
       );
       await openAddStepMenu();
       await act(async () => {
-        fireEvent.click(screen.getByRole("menuitem", { name: "Where labels" }));
+        fireEvent.click(screen.getByRole("menuitem", { name: "Label filter" }));
       });
-      const [labelInput] = screen.getAllByRole("combobox");
+      const labelInput = screen.getByRole("combobox", { name: "Label" });
       fireEvent.change(labelInput, { target: { value: "status" } });
       fireEvent.change(screen.getByPlaceholderText("value"), {
         target: { value: "active" },
@@ -809,7 +809,7 @@ describe("QueryConditionBuilder", () => {
       const [beforeDrag] = onChange.mock.calls.at(-1) as [string];
       expect(Object.keys(JSON.parse(beforeDrag))).toEqual(["&status", "#ext"]);
 
-      // Drag the Transform block above the Where labels block.
+      // Drag the Transform block above the Label filter block.
       act(() => {
         capturedOnDragEnd?.({
           active: { id: "transform" },
@@ -872,19 +872,19 @@ describe("QueryConditionBuilder", () => {
       await openAddStepMenu();
       await act(async () => {
         fireEvent.click(
-          screen.getByRole("menuitem", { name: "Sample by time interval" }),
+          screen.getByRole("menuitem", { name: "Sample by time" }),
         );
       });
       // Sample defaults to the interval macro, so adding it alone doesn't
       // block Run Query.
       expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(false);
 
-      fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
+      fireEvent.change(screen.getByRole("combobox", { name: "Interval" }), {
         target: { value: "" },
       });
       expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(true);
 
-      fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
+      fireEvent.change(screen.getByRole("combobox", { name: "Interval" }), {
         target: { value: "30s" },
       });
       expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(false);
@@ -908,10 +908,10 @@ describe("QueryConditionBuilder", () => {
       await openAddStepMenu();
       expect(screen.queryByRole("menuitem", { name: "Limit" })).toBeNull();
       expect(
-        screen.getByRole("menuitem", { name: "Sample by time interval" }),
+        screen.getByRole("menuitem", { name: "Sample by time" }),
       ).toBeTruthy();
       expect(
-        screen.getByRole("menuitem", { name: "Sample every N records" }),
+        screen.getByRole("menuitem", { name: "Sample every N" }),
       ).toBeTruthy();
     });
 
@@ -926,7 +926,7 @@ describe("QueryConditionBuilder", () => {
             validationContext={readyValidationContext}
           />,
         );
-        expect(screen.getByText("Sample by time interval")).toBeTruthy();
+        expect(screen.getByText("Sample by time")).toBeTruthy();
         expect(screen.getByLabelText("Remove sample step")).toBeTruthy();
       });
 
@@ -944,10 +944,10 @@ describe("QueryConditionBuilder", () => {
         await openAddStepMenu();
         await act(async () => {
           fireEvent.click(
-            screen.getByRole("menuitem", { name: "Where labels" }),
+            screen.getByRole("menuitem", { name: "Label filter" }),
           );
         });
-        const [labelInput] = screen.getAllByRole("combobox");
+        const labelInput = screen.getByRole("combobox", { name: "Label" });
         fireEvent.change(labelInput, { target: { value: "status" } });
         fireEvent.change(screen.getByPlaceholderText("value"), {
           target: { value: "active" },
@@ -972,7 +972,7 @@ describe("QueryConditionBuilder", () => {
           />,
         );
 
-        fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
+        fireEvent.change(screen.getByRole("combobox", { name: "Interval" }), {
           target: { value: "30s" },
         });
         const [afterDuration] = onChange.mock.calls.at(-1) as [string];
@@ -1011,7 +1011,7 @@ describe("QueryConditionBuilder", () => {
           />,
         );
 
-        fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
+        fireEvent.change(screen.getByRole("combobox", { name: "Interval" }), {
           target: { value: "30 s" },
         });
 
@@ -1028,8 +1028,10 @@ describe("QueryConditionBuilder", () => {
             validationContext={readyValidationContext}
           />,
         );
-        expect(screen.getByText("Sample by time interval")).toBeTruthy();
-        expect(screen.getByPlaceholderText("30s, 1m")).toHaveValue("30s");
+        expect(screen.getByText("Sample by time")).toBeTruthy();
+        expect(screen.getByRole("combobox", { name: "Interval" })).toHaveValue(
+          "30s",
+        );
       });
     });
   });
@@ -1134,11 +1136,10 @@ describe("QueryConditionBuilder", () => {
         { target: { value: "/robot/odom" } },
       );
       await addSection("As label");
-      fireEvent.change(
-        screen.getByPlaceholderText("label name (e.g. label_name)"),
-        { target: { value: "speed" } },
-      );
-      fireEvent.change(screen.getByPlaceholderText("field (e.g. latitude)"), {
+      fireEvent.change(screen.getByPlaceholderText("label name (e.g. lat_x)"), {
+        target: { value: "speed" },
+      });
+      fireEvent.change(screen.getByPlaceholderText("field (e.g. latitude.x)"), {
         target: { value: "data.speed" },
       });
 

--- a/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
@@ -768,6 +768,59 @@ describe("QueryConditionBuilder", () => {
       uuidMock.mockRestore();
     });
 
+    it("reorders the JSON's ext key to match a drag-and-drop reorder involving the Transform block", async () => {
+      const onChange = vi.fn();
+      render(
+        <QueryConditionBuilder
+          value=""
+          onChange={onChange}
+          mode="builder"
+          onUnrepresentable={noop}
+          validationContext={readyValidationContext}
+        />,
+      );
+      await openAddStepMenu();
+      await act(async () => {
+        fireEvent.click(screen.getByRole("menuitem", { name: "Where labels" }));
+      });
+      const [labelInput] = screen.getAllByRole("combobox");
+      fireEvent.change(labelInput, { target: { value: "status" } });
+      fireEvent.change(screen.getByPlaceholderText("value"), {
+        target: { value: "active" },
+      });
+
+      await openAddStepMenu();
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("menuitem", { name: "Transform (ReductROS)" }),
+        );
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Add option"));
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Filter"));
+      });
+      fireEvent.change(
+        screen.getByPlaceholderText("optional ROS topic filter"),
+        { target: { value: "/robot/odom" } },
+      );
+
+      const [beforeDrag] = onChange.mock.calls.at(-1) as [string];
+      expect(Object.keys(JSON.parse(beforeDrag))).toEqual(["&status", "#ext"]);
+
+      // Drag the Transform block above the Where labels block.
+      act(() => {
+        capturedOnDragEnd?.({
+          active: { id: "transform" },
+          over: { id: "conditions" },
+        } as DragEndEvent);
+      });
+
+      const [afterDrag] = onChange.mock.calls.at(-1) as [string];
+      expect(Object.keys(JSON.parse(afterDrag))).toEqual(["#ext", "&status"]);
+    });
+
     it("reports an incomplete step once its default count is cleared, and clears once refilled", async () => {
       const onIncompleteConditionChange = vi.fn();
       render(
@@ -980,6 +1033,186 @@ describe("QueryConditionBuilder", () => {
           "30s",
         );
       });
+    });
+  });
+
+  describe("Transform (ReductROS) step", () => {
+    const openAddStepMenu = async () => {
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Add step"));
+      });
+    };
+
+    const addTransformBlock = async () => {
+      await openAddStepMenu();
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("menuitem", { name: "Transform (ReductROS)" }),
+        );
+      });
+    };
+
+    const addSection = async (
+      name: "Filter" | "Encode" | "Label" | "Export",
+    ) => {
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Add option"));
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText(name));
+      });
+    };
+
+    it("adds a fresh transform (no sections yet) via the menu", async () => {
+      render(
+        <QueryConditionBuilder
+          value=""
+          onChange={noop}
+          mode="builder"
+          onUnrepresentable={noop}
+          validationContext={readyValidationContext}
+        />,
+      );
+      await addTransformBlock();
+      expect(screen.getByLabelText("Add option")).toBeTruthy();
+      expect(
+        screen.queryByPlaceholderText("optional ROS topic filter"),
+      ).toBeNull();
+    });
+
+    it("removes the transform via its card's remove button", async () => {
+      render(
+        <QueryConditionBuilder
+          value=""
+          onChange={noop}
+          mode="builder"
+          onUnrepresentable={noop}
+          validationContext={readyValidationContext}
+        />,
+      );
+      await addTransformBlock();
+      fireEvent.click(screen.getByLabelText("Remove transform"));
+      expect(screen.queryByLabelText("Add option")).toBeNull();
+    });
+
+    it("reports a typed topic and as_label mapping through onChange, merged as a #ext key", async () => {
+      const onChange = vi.fn();
+      render(
+        <QueryConditionBuilder
+          value=""
+          onChange={onChange}
+          mode="builder"
+          onUnrepresentable={noop}
+          validationContext={readyValidationContext}
+        />,
+      );
+      await addTransformBlock();
+      await addSection("Filter");
+      fireEvent.change(
+        screen.getByPlaceholderText("optional ROS topic filter"),
+        { target: { value: "/robot/odom" } },
+      );
+      await addSection("Label");
+      fireEvent.change(
+        screen.getByPlaceholderText("label name (e.g. label_name)"),
+        { target: { value: "speed" } },
+      );
+      fireEvent.change(screen.getByPlaceholderText("field (e.g. latitude)"), {
+        target: { value: "data.speed" },
+      });
+
+      const lastValue = onChange.mock.calls.at(-1)?.[0] as string;
+      const parsed = JSON.parse(lastValue);
+      expect(parsed["#ext"].ros.extract).toMatchObject({
+        topic: "/robot/odom",
+        as_label: { speed: "data.speed" },
+      });
+    });
+
+    it("reports an incomplete transform for a half-filled encode row, and clears once both sides are filled", async () => {
+      const onIncompleteConditionChange = vi.fn();
+      render(
+        <QueryConditionBuilder
+          value=""
+          onChange={noop}
+          mode="builder"
+          onUnrepresentable={noop}
+          validationContext={readyValidationContext}
+          onIncompleteConditionChange={onIncompleteConditionChange}
+        />,
+      );
+      await addTransformBlock();
+      await addSection("Encode");
+
+      fireEvent.change(screen.getByPlaceholderText("field (e.g. data)"), {
+        target: { value: "data" },
+      });
+      expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(true);
+
+      fireEvent.change(screen.getByPlaceholderText("encoding (e.g. jpeg)"), {
+        target: { value: "jpeg" },
+      });
+      expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it("shows a transform carried in the value prop's #ext key, without needing to be added", () => {
+      const value = JSON.stringify({
+        "#ext": {
+          ros: {
+            extract: {
+              topic: "/robot/odom",
+              as_label: { speed: "data.speed" },
+            },
+          },
+        },
+      });
+      render(
+        <QueryConditionBuilder
+          value={value}
+          onChange={noop}
+          mode="builder"
+          onUnrepresentable={noop}
+          validationContext={readyValidationContext}
+        />,
+      );
+      expect(screen.getByText("Transform (ReductROS)")).toBeTruthy();
+      expect(
+        screen.getByPlaceholderText("optional ROS topic filter"),
+      ).toHaveValue("/robot/odom");
+    });
+
+    it("resyncs when the value prop's #ext key changes from outside while already in builder mode", () => {
+      const { rerender } = render(
+        <QueryConditionBuilder
+          value=""
+          onChange={noop}
+          mode="builder"
+          onUnrepresentable={noop}
+          validationContext={readyValidationContext}
+        />,
+      );
+      expect(screen.queryByText("Transform (ReductROS)")).toBeNull();
+
+      const value = JSON.stringify({
+        "#ext": {
+          ros: {
+            extract: {
+              topic: "/robot/odom",
+              as_label: { speed: "data.speed" },
+            },
+          },
+        },
+      });
+      rerender(
+        <QueryConditionBuilder
+          value={value}
+          onChange={noop}
+          mode="builder"
+          onUnrepresentable={noop}
+          validationContext={readyValidationContext}
+        />,
+      );
+      expect(screen.getByText("Transform (ReductROS)")).toBeTruthy();
     });
   });
 });

--- a/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
@@ -524,7 +524,7 @@ describe("QueryConditionBuilder", () => {
           screen.getByRole("menuitem", { name: "Sample by time interval" }),
         );
       });
-      fireEvent.change(screen.getByPlaceholderText("duration (e.g. 30s)"), {
+      fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
         target: { value: "30s" },
       });
 
@@ -577,7 +577,7 @@ describe("QueryConditionBuilder", () => {
           screen.getByRole("menuitem", { name: "Sample by time interval" }),
         );
       });
-      fireEvent.change(screen.getByPlaceholderText("duration (e.g. 30s)"), {
+      fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
         target: { value: "1s" },
       });
 
@@ -693,7 +693,7 @@ describe("QueryConditionBuilder", () => {
           screen.getByRole("menuitem", { name: "Sample by time interval" }),
         );
       });
-      fireEvent.change(screen.getByPlaceholderText("duration (e.g. 30s)"), {
+      fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
         target: { value: "30s" },
       });
       await openAddStepMenu();
@@ -879,12 +879,12 @@ describe("QueryConditionBuilder", () => {
       // block Run Query.
       expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(false);
 
-      fireEvent.change(screen.getByPlaceholderText("duration (e.g. 30s)"), {
+      fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
         target: { value: "" },
       });
       expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(true);
 
-      fireEvent.change(screen.getByPlaceholderText("duration (e.g. 30s)"), {
+      fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
         target: { value: "30s" },
       });
       expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(false);
@@ -972,7 +972,7 @@ describe("QueryConditionBuilder", () => {
           />,
         );
 
-        fireEvent.change(screen.getByPlaceholderText("duration (e.g. 30s)"), {
+        fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
           target: { value: "30s" },
         });
         const [afterDuration] = onChange.mock.calls.at(-1) as [string];
@@ -1011,7 +1011,7 @@ describe("QueryConditionBuilder", () => {
           />,
         );
 
-        fireEvent.change(screen.getByPlaceholderText("duration (e.g. 30s)"), {
+        fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
           target: { value: "30 s" },
         });
 
@@ -1029,9 +1029,7 @@ describe("QueryConditionBuilder", () => {
           />,
         );
         expect(screen.getByText("Sample by time interval")).toBeTruthy();
-        expect(screen.getByPlaceholderText("duration (e.g. 30s)")).toHaveValue(
-          "30s",
-        );
+        expect(screen.getByPlaceholderText("30s, 1m")).toHaveValue("30s");
       });
     });
   });

--- a/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
@@ -112,7 +112,7 @@ describe("QueryConditionBuilder", () => {
     expect(screen.getByPlaceholderText("value")).toBeTruthy();
   });
 
-  it("hides every block and disables Add step until a bucket and entry are selected", () => {
+  it("hides every block until a bucket and entry are selected, but keeps Add step reachable and greys out its menu", async () => {
     render(
       <QueryConditionBuilder
         value=""
@@ -123,7 +123,13 @@ describe("QueryConditionBuilder", () => {
     );
     expect(screen.getByText("Query")).toBeTruthy();
     expect(screen.queryByPlaceholderText("value")).toBeNull();
-    expect(screen.getByLabelText("Add step")).toBeDisabled();
+    expect(screen.getByLabelText("Add step")).not.toBeDisabled();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Add step"));
+    });
+    expect(
+      screen.getByRole("menuitem", { name: "Label filter" }),
+    ).toHaveAttribute("aria-disabled", "true");
   });
 
   it("shows the JSON editor with the current value in json mode", () => {
@@ -598,7 +604,7 @@ describe("QueryConditionBuilder", () => {
       });
     });
 
-    it("offers neither Sample kind in the menu once each_n and each_t are both present", async () => {
+    it("greys out both Sample kinds in the menu once each_n and each_t are both present", async () => {
       render(
         <QueryConditionBuilder
           value=""
@@ -623,11 +629,11 @@ describe("QueryConditionBuilder", () => {
 
       await openAddStepMenu();
       expect(
-        screen.queryByRole("menuitem", { name: "Sample by time" }),
-      ).toBeNull();
+        screen.getByRole("menuitem", { name: "Sample by time" }),
+      ).toHaveAttribute("aria-disabled", "true");
       expect(
-        screen.queryByRole("menuitem", { name: "Sample every N" }),
-      ).toBeNull();
+        screen.getByRole("menuitem", { name: "Sample every N" }),
+      ).toHaveAttribute("aria-disabled", "true");
     });
 
     it("adds a limit step and combines it with an existing filter", async () => {
@@ -890,7 +896,7 @@ describe("QueryConditionBuilder", () => {
       expect(onIncompleteConditionChange).toHaveBeenLastCalledWith(false);
     });
 
-    it("removes the matching menu item once limit is already added", async () => {
+    it("greys out the matching menu item once limit is already added", async () => {
       render(
         <QueryConditionBuilder
           value=""
@@ -906,7 +912,10 @@ describe("QueryConditionBuilder", () => {
         fireEvent.click(screen.getByRole("menuitem", { name: "Limit" }));
       });
       await openAddStepMenu();
-      expect(screen.queryByRole("menuitem", { name: "Limit" })).toBeNull();
+      expect(screen.getByRole("menuitem", { name: "Limit" })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
       expect(
         screen.getByRole("menuitem", { name: "Sample by time" }),
       ).toBeTruthy();

--- a/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
+++ b/src/Components/QueryConditionBuilder/QueryConditionBuilder.test.tsx
@@ -792,7 +792,7 @@ describe("QueryConditionBuilder", () => {
       await openAddStepMenu();
       await act(async () => {
         fireEvent.click(
-          screen.getByRole("menuitem", { name: "Transform (ReductROS)" }),
+          screen.getByRole("menuitem", { name: "Process (ROS)" }),
         );
       });
       await act(async () => {
@@ -1036,7 +1036,7 @@ describe("QueryConditionBuilder", () => {
     });
   });
 
-  describe("Transform (ReductROS) step", () => {
+  describe("Process (ROS) step", () => {
     const openAddStepMenu = async () => {
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Add step"));
@@ -1047,7 +1047,7 @@ describe("QueryConditionBuilder", () => {
       await openAddStepMenu();
       await act(async () => {
         fireEvent.click(
-          screen.getByRole("menuitem", { name: "Transform (ReductROS)" }),
+          screen.getByRole("menuitem", { name: "Process (ROS)" }),
         );
       });
     };
@@ -1091,7 +1091,7 @@ describe("QueryConditionBuilder", () => {
         />,
       );
       await addTransformBlock();
-      fireEvent.click(screen.getByLabelText("Remove transform"));
+      fireEvent.click(screen.getByLabelText("Remove process"));
       expect(screen.queryByLabelText("Add option")).toBeNull();
     });
 
@@ -1175,7 +1175,7 @@ describe("QueryConditionBuilder", () => {
           validationContext={readyValidationContext}
         />,
       );
-      expect(screen.getByText("Transform (ReductROS)")).toBeTruthy();
+      expect(screen.getByText("Process (ROS)")).toBeTruthy();
       expect(
         screen.getByPlaceholderText("optional ROS topic filter"),
       ).toHaveValue("/robot/odom");
@@ -1191,7 +1191,7 @@ describe("QueryConditionBuilder", () => {
           validationContext={readyValidationContext}
         />,
       );
-      expect(screen.queryByText("Transform (ReductROS)")).toBeNull();
+      expect(screen.queryByText("Process (ROS)")).toBeNull();
 
       const value = JSON.stringify({
         "#ext": {
@@ -1212,7 +1212,7 @@ describe("QueryConditionBuilder", () => {
           validationContext={readyValidationContext}
         />,
       );
-      expect(screen.getByText("Transform (ReductROS)")).toBeTruthy();
+      expect(screen.getByText("Process (ROS)")).toBeTruthy();
     });
   });
 });

--- a/src/Components/QueryConditionBuilder/QueryConditionBuilder.tsx
+++ b/src/Components/QueryConditionBuilder/QueryConditionBuilder.tsx
@@ -109,6 +109,8 @@ const STEP_KEYS: Record<Step["type"], string> = {
   limit: "$limit",
 };
 
+const KEEP_TRANSFORM = Symbol("keep-transform");
+
 function reorderQueryKeys(
   value: Record<string, unknown>,
   blockOrder: string[],
@@ -284,13 +286,15 @@ export default function QueryConditionBuilder({
   const applyQuery = (
     nextConditions: FlatCondition[],
     nextSteps: Step[],
-    nextTransform: TransformStepEntry | undefined = transformState,
+    nextTransform: TransformStepEntry | undefined | typeof KEEP_TRANSFORM,
     nextBlockOrder: string[] = blockOrder,
   ) => {
+    const resolvedTransform =
+      nextTransform === KEEP_TRANSFORM ? transformState : nextTransform;
     setConditions(nextConditions);
     setSteps(nextSteps);
-    setTransformState(nextTransform);
-    const extPayload = buildExtPayload(nextTransform);
+    setTransformState(resolvedTransform);
+    const extPayload = buildExtPayload(resolvedTransform);
     const merged = {
       ...serializeBuilderList(nextConditions),
       ...serializeSteps(nextSteps),
@@ -339,42 +343,60 @@ export default function QueryConditionBuilder({
         labelOptions={labelOptions}
         intervalValue={validationContext?.intervalValue ?? undefined}
         onChangeCondition={(id, changes) =>
-          applyQuery(updateCondition(conditions, id, changes), steps)
+          applyQuery(
+            updateCondition(conditions, id, changes),
+            steps,
+            KEEP_TRANSFORM,
+          )
         }
         onRemoveCondition={(id) =>
-          applyQuery(removeCondition(conditions, id), steps)
+          applyQuery(removeCondition(conditions, id), steps, KEEP_TRANSFORM)
         }
-        onAddCondition={() => applyQuery(addCondition(conditions), steps)}
+        onAddCondition={() =>
+          applyQuery(addCondition(conditions), steps, KEEP_TRANSFORM)
+        }
         onChangeEachN={(id, changes) =>
-          applyQuery(conditions, updateEachNStep(steps, id, changes))
+          applyQuery(
+            conditions,
+            updateEachNStep(steps, id, changes),
+            KEEP_TRANSFORM,
+          )
         }
         onChangeEachT={(id, changes) =>
-          applyQuery(conditions, updateEachTStep(steps, id, changes))
+          applyQuery(
+            conditions,
+            updateEachTStep(steps, id, changes),
+            KEEP_TRANSFORM,
+          )
         }
         onChangeLimit={(id, changes) =>
-          applyQuery(conditions, updateLimitStep(steps, id, changes))
+          applyQuery(
+            conditions,
+            updateLimitStep(steps, id, changes),
+            KEEP_TRANSFORM,
+          )
         }
         onAddConditionsBlock={() => {
-          applyQuery(addCondition(conditions), steps);
+          applyQuery(addCondition(conditions), steps, KEEP_TRANSFORM);
           appendBlock(CONDITIONS_BLOCK_ID);
         }}
         onRemoveConditionsBlock={() => {
-          applyQuery([], steps);
+          applyQuery([], steps, KEEP_TRANSFORM);
           removeBlock(CONDITIONS_BLOCK_ID);
         }}
         onAddEachT={() => {
           const nextSteps = addEachTStep(steps);
-          applyQuery(conditions, nextSteps);
+          applyQuery(conditions, nextSteps, KEEP_TRANSFORM);
           appendBlock(nextSteps[nextSteps.length - 1].id);
         }}
         onAddEachN={() => {
           const nextSteps = addEachNStep(steps);
-          applyQuery(conditions, nextSteps);
+          applyQuery(conditions, nextSteps, KEEP_TRANSFORM);
           appendBlock(nextSteps[nextSteps.length - 1].id);
         }}
         onAddLimit={() => {
           const nextSteps = addLimitStep(steps);
-          applyQuery(conditions, nextSteps);
+          applyQuery(conditions, nextSteps, KEEP_TRANSFORM);
           appendBlock(nextSteps[nextSteps.length - 1].id);
         }}
         onAddTransformBlock={() => {
@@ -434,7 +456,7 @@ export default function QueryConditionBuilder({
           applyQuery(conditions, steps, updateExport(transformState, changes))
         }
         onRemoveStep={(id) => {
-          applyQuery(conditions, removeStep(steps, id));
+          applyQuery(conditions, removeStep(steps, id), KEEP_TRANSFORM);
           removeBlock(id);
         }}
         onReorderBlock={(fromIndex, toIndex) => {

--- a/src/Components/QueryConditionBuilder/QueryConditionBuilder.tsx
+++ b/src/Components/QueryConditionBuilder/QueryConditionBuilder.tsx
@@ -13,7 +13,7 @@ import {
   hasIncompleteSteps,
   hasValue,
   moveItem,
-  parseQueryValue,
+  parseBuilderList,
   removeCondition,
   removeStep,
   serializeBuilderList,
@@ -23,7 +23,27 @@ import {
   updateEachTStep,
   updateLimitStep,
 } from "../../Helpers/conditionalQueryBuilder";
-import { formatAsStrictJSON } from "../../Helpers/json5Utils";
+import {
+  addAsLabelRow,
+  addEncodeRow,
+  addSection,
+  buildExtPayload,
+  createRosTransformStep,
+  hasIncompleteTransform,
+  parseExtPayload,
+  removeAsLabelRow,
+  removeEncodeRow,
+  removeSection,
+  RosExportConfig,
+  RosSection,
+  TransformStepEntry,
+  TRANSFORM_BLOCK_ID,
+  updateAsLabelRow,
+  updateEncodeRow,
+  updateExport,
+  updateTopic,
+} from "../../Helpers/transformStepBuilder";
+import { formatAsStrictJSON, safeParseJSON5 } from "../../Helpers/json5Utils";
 import { QueryOptions } from "reduct-js";
 
 type ValidationContext = ComponentProps<
@@ -33,11 +53,54 @@ type ValidationContext = ComponentProps<
 function initialBlockOrder(
   conditions: FlatCondition[],
   steps: Step[],
+  transform: TransformStepEntry | undefined,
 ): string[] {
   return [
     ...(conditions.length > 0 ? [CONDITIONS_BLOCK_ID] : []),
     ...steps.map((step) => step.id),
+    ...(transform ? [TRANSFORM_BLOCK_ID] : []),
   ];
+}
+
+interface ParsedQueryAndTransform {
+  list: FlatCondition[];
+  steps?: Step[];
+  transform?: TransformStepEntry;
+}
+
+// Mirrors conditionalQueryBuilder's own parseQueryValue, but also splits out
+// the "#ext" sibling key this file merges into the same text (see
+// applyQuery) before handing the rest to the condition/step parser - kept
+// here rather than in either Helper module so neither has to import the
+// other.
+function parseQueryAndTransform(
+  text: string,
+): ParsedQueryAndTransform | undefined {
+  const parsed = safeParseJSON5(text);
+  if (!parsed.success) {
+    return undefined;
+  }
+  const raw = parsed.value;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    const result = parseBuilderList(raw);
+    return result.success
+      ? { list: result.list ?? [], steps: result.steps }
+      : undefined;
+  }
+  const { "#ext": ext, ...rest } = raw as Record<string, unknown>;
+  const extResult = parseExtPayload(ext);
+  if (!extResult.success) {
+    return undefined;
+  }
+  const result = parseBuilderList(rest);
+  if (!result.success) {
+    return undefined;
+  }
+  return {
+    list: result.list ?? [],
+    steps: result.steps,
+    transform: extResult.transform,
+  };
 }
 
 const STEP_KEYS: Record<Step["type"], string> = {
@@ -55,7 +118,11 @@ function reorderQueryKeys(
     steps.map((step) => [step.id, STEP_KEYS[step.type]]),
   );
   const conditionsKey = Object.keys(value).find(
-    (key) => key !== "$each_n" && key !== "$each_t" && key !== "$limit",
+    (key) =>
+      key !== "$each_n" &&
+      key !== "$each_t" &&
+      key !== "$limit" &&
+      key !== "#ext",
   );
 
   const orderedKeys: string[] = [];
@@ -63,7 +130,9 @@ function reorderQueryKeys(
     const key =
       blockId === CONDITIONS_BLOCK_ID
         ? conditionsKey
-        : stepKeyById.get(blockId);
+        : blockId === TRANSFORM_BLOCK_ID
+          ? "#ext"
+          : stepKeyById.get(blockId);
     if (key !== undefined && key in value && !orderedKeys.includes(key)) {
       orderedKeys.push(key);
     }
@@ -101,10 +170,11 @@ export default function QueryConditionBuilder({
   onIncompleteConditionChange,
 }: QueryConditionBuilderProps) {
   const [initial] = useState(() => {
-    const parsed = parseQueryValue(value);
+    const parsed = parseQueryAndTransform(value);
     return {
       conditions: parsed?.list ?? [],
       steps: parsed?.steps ?? [],
+      transform: parsed?.transform,
     };
   });
 
@@ -113,8 +183,12 @@ export default function QueryConditionBuilder({
   );
   const [steps, setSteps] = useState<Step[]>(initial.steps);
 
+  const [transformState, setTransformState] = useState<
+    TransformStepEntry | undefined
+  >(initial.transform);
+
   const [blockOrder, setBlockOrder] = useState<string[]>(() =>
-    initialBlockOrder(initial.conditions, initial.steps),
+    initialBlockOrder(initial.conditions, initial.steps, initial.transform),
   );
 
   const lastEmittedValueRef = useRef(value);
@@ -180,7 +254,7 @@ export default function QueryConditionBuilder({
       return;
     }
     lastEmittedValueRef.current = value;
-    const parsed = parseQueryValue(value);
+    const parsed = parseQueryAndTransform(value);
     if (parsed === undefined) {
       onUnrepresentable();
       return;
@@ -188,7 +262,8 @@ export default function QueryConditionBuilder({
     setConditions(parsed.list);
     const nextSteps = parsed.steps ?? [];
     setSteps(nextSteps);
-    setBlockOrder(initialBlockOrder(parsed.list, nextSteps));
+    setTransformState(parsed.transform);
+    setBlockOrder(initialBlockOrder(parsed.list, nextSteps, parsed.transform));
   }, [value, mode]);
 
   useEffect(() => {
@@ -200,20 +275,26 @@ export default function QueryConditionBuilder({
       conditions.some(
         (condition) =>
           (condition.label.trim() !== "") !== hasValue(condition.value),
-      ) || hasIncompleteSteps(steps);
+      ) ||
+      hasIncompleteSteps(steps) ||
+      hasIncompleteTransform(transformState);
     onIncompleteConditionChange?.(hasIncomplete);
-  }, [conditions, steps, mode]);
+  }, [conditions, steps, transformState, mode]);
 
   const applyQuery = (
     nextConditions: FlatCondition[],
     nextSteps: Step[],
+    nextTransform: TransformStepEntry | undefined = transformState,
     nextBlockOrder: string[] = blockOrder,
   ) => {
     setConditions(nextConditions);
     setSteps(nextSteps);
+    setTransformState(nextTransform);
+    const extPayload = buildExtPayload(nextTransform);
     const merged = {
       ...serializeBuilderList(nextConditions),
       ...serializeSteps(nextSteps),
+      ...(extPayload ? { "#ext": extPayload } : {}),
     };
     const nextValue = reorderQueryKeys(merged, nextBlockOrder, nextSteps);
     const formatted = formatAsStrictJSON(nextValue);
@@ -253,6 +334,7 @@ export default function QueryConditionBuilder({
         blockOrder={blockOrder}
         conditions={conditions}
         steps={steps}
+        transform={transformState}
         sourceReady={sourceReady}
         labelOptions={labelOptions}
         intervalValue={validationContext?.intervalValue ?? undefined}
@@ -295,6 +377,62 @@ export default function QueryConditionBuilder({
           applyQuery(conditions, nextSteps);
           appendBlock(nextSteps[nextSteps.length - 1].id);
         }}
+        onAddTransformBlock={() => {
+          applyQuery(conditions, steps, createRosTransformStep());
+          appendBlock(TRANSFORM_BLOCK_ID);
+        }}
+        onRemoveTransformBlock={() => {
+          applyQuery(conditions, steps, undefined);
+          removeBlock(TRANSFORM_BLOCK_ID);
+        }}
+        onAddSection={(section: RosSection) =>
+          transformState &&
+          applyQuery(conditions, steps, addSection(transformState, section))
+        }
+        onRemoveSection={(section: RosSection) =>
+          transformState &&
+          applyQuery(conditions, steps, removeSection(transformState, section))
+        }
+        onChangeTopic={(topic: string) =>
+          transformState &&
+          applyQuery(conditions, steps, updateTopic(transformState, topic))
+        }
+        onAddEncodeRow={() =>
+          transformState &&
+          applyQuery(conditions, steps, addEncodeRow(transformState))
+        }
+        onChangeEncodeRow={(id, changes) =>
+          transformState &&
+          applyQuery(
+            conditions,
+            steps,
+            updateEncodeRow(transformState, id, changes),
+          )
+        }
+        onRemoveEncodeRow={(id) =>
+          transformState &&
+          applyQuery(conditions, steps, removeEncodeRow(transformState, id))
+        }
+        onAddAsLabelRow={() =>
+          transformState &&
+          applyQuery(conditions, steps, addAsLabelRow(transformState))
+        }
+        onChangeAsLabelRow={(id, changes) =>
+          transformState &&
+          applyQuery(
+            conditions,
+            steps,
+            updateAsLabelRow(transformState, id, changes),
+          )
+        }
+        onRemoveAsLabelRow={(id) =>
+          transformState &&
+          applyQuery(conditions, steps, removeAsLabelRow(transformState, id))
+        }
+        onChangeExport={(changes: Partial<RosExportConfig>) =>
+          transformState &&
+          applyQuery(conditions, steps, updateExport(transformState, changes))
+        }
         onRemoveStep={(id) => {
           applyQuery(conditions, removeStep(steps, id));
           removeBlock(id);
@@ -302,7 +440,7 @@ export default function QueryConditionBuilder({
         onReorderBlock={(fromIndex, toIndex) => {
           const nextBlockOrder = moveItem(blockOrder, fromIndex, toIndex);
           setBlockOrder(nextBlockOrder);
-          applyQuery(conditions, steps, nextBlockOrder);
+          applyQuery(conditions, steps, transformState, nextBlockOrder);
         }}
       />
       {error && (

--- a/src/Components/QueryConditionBuilder/SampleStepEditor.test.tsx
+++ b/src/Components/QueryConditionBuilder/SampleStepEditor.test.tsx
@@ -20,9 +20,7 @@ const eachNProps = {
 describe("SampleStepEditor", () => {
   it("shows the current duration", () => {
     render(<SampleStepEditor {...eachTProps} duration="30s" />);
-    expect(screen.getByPlaceholderText("duration (e.g. 30s)")).toHaveValue(
-      "30s",
-    );
+    expect(screen.getByPlaceholderText("30s, 1m")).toHaveValue("30s");
   });
 
   it("shows the literal $__interval macro in the duration field while using the macro", () => {
@@ -33,9 +31,7 @@ describe("SampleStepEditor", () => {
         intervalValue="30s"
       />,
     );
-    expect(screen.getByPlaceholderText("duration (e.g. 30s)")).toHaveValue(
-      "$__interval",
-    );
+    expect(screen.getByPlaceholderText("30s, 1m")).toHaveValue("$__interval");
   });
 
   it("shows the resolved interval value next to the input while using the macro", () => {
@@ -59,7 +55,7 @@ describe("SampleStepEditor", () => {
   it("reports a typed duration and switches off the interval macro", () => {
     const onChangeEachT = vi.fn();
     render(<SampleStepEditor {...eachTProps} onChangeEachT={onChangeEachT} />);
-    fireEvent.change(screen.getByPlaceholderText("duration (e.g. 30s)"), {
+    fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
       target: { value: "1m" },
     });
     expect(onChangeEachT).toHaveBeenCalledWith({

--- a/src/Components/QueryConditionBuilder/SampleStepEditor.test.tsx
+++ b/src/Components/QueryConditionBuilder/SampleStepEditor.test.tsx
@@ -20,7 +20,9 @@ const eachNProps = {
 describe("SampleStepEditor", () => {
   it("shows the current duration", () => {
     render(<SampleStepEditor {...eachTProps} duration="30s" />);
-    expect(screen.getByPlaceholderText("30s, 1m")).toHaveValue("30s");
+    expect(screen.getByRole("combobox", { name: "Interval" })).toHaveValue(
+      "30s",
+    );
   });
 
   it("shows the literal $__interval macro in the duration field while using the macro", () => {
@@ -31,7 +33,9 @@ describe("SampleStepEditor", () => {
         intervalValue="30s"
       />,
     );
-    expect(screen.getByPlaceholderText("30s, 1m")).toHaveValue("$__interval");
+    expect(screen.getByRole("combobox", { name: "Interval" })).toHaveValue(
+      "$__interval",
+    );
   });
 
   it("shows the resolved interval value next to the input while using the macro", () => {
@@ -55,13 +59,28 @@ describe("SampleStepEditor", () => {
   it("reports a typed duration and switches off the interval macro", () => {
     const onChangeEachT = vi.fn();
     render(<SampleStepEditor {...eachTProps} onChangeEachT={onChangeEachT} />);
-    fireEvent.change(screen.getByPlaceholderText("30s, 1m"), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Interval" }), {
       target: { value: "1m" },
     });
     expect(onChangeEachT).toHaveBeenCalledWith({
       duration: "1m",
       useIntervalMacro: false,
     });
+  });
+
+  it("re-enables the interval macro when $__interval is typed back in", () => {
+    const onChangeEachT = vi.fn();
+    render(
+      <SampleStepEditor
+        {...eachTProps}
+        duration="1m"
+        onChangeEachT={onChangeEachT}
+      />,
+    );
+    fireEvent.change(screen.getByRole("combobox", { name: "Interval" }), {
+      target: { value: "$__interval" },
+    });
+    expect(onChangeEachT).toHaveBeenCalledWith({ useIntervalMacro: true });
   });
 
   it("shows a plain number field for each_n and reports a typed count", () => {

--- a/src/Components/QueryConditionBuilder/SampleStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/SampleStepEditor.tsx
@@ -4,7 +4,7 @@ import {
   EachTStep,
   SampleKind,
 } from "../../Helpers/conditionalQueryBuilder";
-import { ROW_LABEL_WIDTH } from "./stepRowLayout";
+import { ROW_LABEL_WIDTH, VALUE_INPUT_WIDTH } from "./stepRowLayout";
 
 const DURATION_SUGGESTIONS = [
   "$__interval",
@@ -61,7 +61,7 @@ export default function SampleStepEditor({
           placeholder="every Nth record"
           value={everyNth}
           onChange={(value) => onChangeEachN({ everyNth: value ?? undefined })}
-          style={{ width: 140 }}
+          style={{ width: VALUE_INPUT_WIDTH / 2 }}
         />
       ) : (
         <AutoComplete
@@ -74,7 +74,7 @@ export default function SampleStepEditor({
               : onChangeEachT({ duration: value, useIntervalMacro: false })
           }
           placeholder="30s, 1m"
-          style={{ width: 140 }}
+          style={{ width: VALUE_INPUT_WIDTH }}
           popupMatchSelectWidth={false}
         />
       )}

--- a/src/Components/QueryConditionBuilder/SampleStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/SampleStepEditor.tsx
@@ -1,9 +1,24 @@
-import { Input, InputNumber, Typography } from "antd";
+import { AutoComplete, InputNumber, Typography } from "antd";
 import {
   EachNStep,
   EachTStep,
   SampleKind,
 } from "../../Helpers/conditionalQueryBuilder";
+import { ROW_LABEL_WIDTH } from "./stepRowLayout";
+
+const DURATION_SUGGESTIONS = [
+  "$__interval",
+  "1s",
+  "2s",
+  "5s",
+  "10s",
+  "30s",
+  "1m",
+  "5m",
+  "10m",
+  "30m",
+  "1h",
+].map((value) => ({ value }));
 
 interface SampleStepEditorProps {
   kind: SampleKind;
@@ -34,6 +49,12 @@ export default function SampleStepEditor({
         minWidth: 0,
       }}
     >
+      <Typography.Text
+        strong
+        style={{ width: ROW_LABEL_WIDTH, flexShrink: 0, fontSize: 12 }}
+      >
+        {kind === "each_n" ? "Step" : "Interval"}
+      </Typography.Text>
       {kind === "each_n" ? (
         <InputNumber
           min={1}
@@ -43,16 +64,18 @@ export default function SampleStepEditor({
           style={{ width: 140 }}
         />
       ) : (
-        <Input
-          placeholder="30s, 1m"
+        <AutoComplete
+          aria-label="Interval"
+          options={DURATION_SUGGESTIONS}
           value={useIntervalMacro ? "$__interval" : duration}
-          onChange={(e) =>
-            onChangeEachT({
-              duration: e.target.value,
-              useIntervalMacro: false,
-            })
+          onChange={(value) =>
+            value === "$__interval"
+              ? onChangeEachT({ useIntervalMacro: true })
+              : onChangeEachT({ duration: value, useIntervalMacro: false })
           }
+          placeholder="30s, 1m"
           style={{ width: 140 }}
+          popupMatchSelectWidth={false}
         />
       )}
       {kind === "each_t" && useIntervalMacro && intervalValue && (

--- a/src/Components/QueryConditionBuilder/SampleStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/SampleStepEditor.tsx
@@ -44,7 +44,7 @@ export default function SampleStepEditor({
         />
       ) : (
         <Input
-          placeholder="duration (e.g. 30s)"
+          placeholder="30s, 1m"
           value={useIntervalMacro ? "$__interval" : duration}
           onChange={(e) =>
             onChangeEachT({

--- a/src/Components/QueryConditionBuilder/SortableCard.tsx
+++ b/src/Components/QueryConditionBuilder/SortableCard.tsx
@@ -10,7 +10,6 @@ interface SortableCardProps {
   removeLabel?: string;
   onRemove: () => void;
   removable?: boolean;
-  inline?: boolean;
   isOverlay?: boolean;
   children: ReactNode;
 }
@@ -21,7 +20,6 @@ export default function SortableCard({
   removeLabel,
   onRemove,
   removable = true,
-  inline = false,
   isOverlay = false,
   children,
 }: SortableCardProps) {
@@ -69,32 +67,13 @@ export default function SortableCard({
           <HolderOutlined />
         </span>
         {label && (
-          <Typography.Text
-            strong
-            className="queryCardLabel"
-            style={
-              inline ? { flex: "0 0 auto", whiteSpace: "nowrap" } : undefined
-            }
-          >
+          <Typography.Text strong className="queryCardLabel">
             {label}
           </Typography.Text>
         )}
-        {inline && (
-          <div
-            style={{
-              flex: 1,
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              minWidth: 0,
-            }}
-          >
-            {children}
-          </div>
-        )}
         {removeButton}
       </div>
-      {!inline && <div className="queryCardBody">{children}</div>}
+      <div className="queryCardBody">{children}</div>
     </div>
   );
 }

--- a/src/Components/QueryConditionBuilder/TransformStepEditor.test.tsx
+++ b/src/Components/QueryConditionBuilder/TransformStepEditor.test.tsx
@@ -255,7 +255,7 @@ describe("TransformStepEditor", () => {
           onRemoveSection={onRemoveSection}
         />,
       );
-      fireEvent.click(screen.getByLabelText("Remove label"));
+      fireEvent.click(screen.getByLabelText("Remove as label"));
       expect(onRemoveSection).toHaveBeenCalledWith("label");
     });
   });

--- a/src/Components/QueryConditionBuilder/TransformStepEditor.test.tsx
+++ b/src/Components/QueryConditionBuilder/TransformStepEditor.test.tsx
@@ -47,7 +47,7 @@ describe("TransformStepEditor", () => {
     expect(onAddSection).toHaveBeenCalledWith("filter");
   });
 
-  it("hides Export from the menu once Filter/Encode/Label is added, and vice versa", async () => {
+  it("greys out Export once Filter/Encode/Label is added, and vice versa, but always shows all four options", async () => {
     const withFilter: RosTransformStep = {
       ...baseStep,
       sections: ["filter"],
@@ -55,21 +55,32 @@ describe("TransformStepEditor", () => {
     };
     render(<TransformStepEditor step={withFilter} {...noopHandlers} />);
     fireEvent.click(screen.getByLabelText("Add option"));
-    expect(await screen.findByText("Encode")).toBeTruthy();
-    expect(screen.queryByText("Export")).toBeNull();
+    expect(
+      await screen.findByRole("menuitem", { name: "Encode" }),
+    ).not.toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("menuitem", { name: "Export" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
   });
 
-  it("leaves no addable section once Export is added, since it's mutually exclusive with the other three", () => {
+  it("greys out all four options once Export is added, since it's mutually exclusive with the other three", async () => {
     const withExport: RosTransformStep = {
       ...baseStep,
       sections: ["export"],
       export: { format: "mcap", duration: "", size: "" },
     };
     render(<TransformStepEditor step={withExport} {...noopHandlers} />);
-    expect(screen.queryByLabelText("Add option")).toBeNull();
+    fireEvent.click(screen.getByLabelText("Add option"));
+    for (const name of ["Filter", "Encode", "As label", "Export"]) {
+      expect(await screen.findByRole("menuitem", { name })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+    }
   });
 
-  it("disables (but keeps visible) Add option once all four sections are added and no row is ready to duplicate", () => {
+  it("keeps Add option enabled even when every section is already added", () => {
     const step: RosTransformStep = {
       ...baseStep,
       sections: ["filter", "encode", "label", "export"],
@@ -77,7 +88,7 @@ describe("TransformStepEditor", () => {
       asLabel: [{ id: "l1", key: "", value: "" }],
     };
     render(<TransformStepEditor step={step} {...noopHandlers} />);
-    expect(screen.getByLabelText("Add option")).toBeDisabled();
+    expect(screen.getByLabelText("Add option")).not.toBeDisabled();
   });
 
   describe("Filter section", () => {
@@ -166,7 +177,7 @@ describe("TransformStepEditor", () => {
       expect(onRemoveSection).toHaveBeenCalledWith("encode");
     });
 
-    it("offers Add encode row from the single Add option menu when the last row is complete", async () => {
+    it("adds another encode row when Encode is picked again from the menu", async () => {
       const onAddEncodeRow = vi.fn();
       render(
         <TransformStepEditor
@@ -176,19 +187,27 @@ describe("TransformStepEditor", () => {
         />,
       );
       fireEvent.click(screen.getByLabelText("Add option"));
-      fireEvent.click(await screen.findByText("Add encode row"));
+      fireEvent.click(await screen.findByRole("menuitem", { name: "Encode" }));
       expect(onAddEncodeRow).toHaveBeenCalled();
     });
 
-    it("omits Add encode row from the menu until the last row is complete", async () => {
+    it("still allows adding another encode row even when the last row is incomplete", async () => {
+      const onAddEncodeRow = vi.fn();
       const partial: RosTransformStep = {
         ...baseStep,
         sections: ["encode"],
         encode: [{ id: "e1", key: "data", value: "" }],
       };
-      render(<TransformStepEditor step={partial} {...noopHandlers} />);
+      render(
+        <TransformStepEditor
+          step={partial}
+          {...noopHandlers}
+          onAddEncodeRow={onAddEncodeRow}
+        />,
+      );
       fireEvent.click(screen.getByLabelText("Add option"));
-      expect(screen.queryByText("Add encode row")).toBeNull();
+      fireEvent.click(await screen.findByRole("menuitem", { name: "Encode" }));
+      expect(onAddEncodeRow).toHaveBeenCalled();
     });
   });
 
@@ -208,15 +227,14 @@ describe("TransformStepEditor", () => {
           onChangeAsLabelRow={onChangeAsLabelRow}
         />,
       );
-      fireEvent.change(
-        screen.getByPlaceholderText("label name (e.g. label_name)"),
-        { target: { value: "velocity" } },
-      );
+      fireEvent.change(screen.getByPlaceholderText("label name (e.g. lat_x)"), {
+        target: { value: "velocity" },
+      });
       expect(onChangeAsLabelRow).toHaveBeenCalledWith("l1", {
         key: "velocity",
       });
 
-      fireEvent.change(screen.getByPlaceholderText("field (e.g. latitude)"), {
+      fireEvent.change(screen.getByPlaceholderText("field (e.g. latitude.x)"), {
         target: { value: "data.speed" },
       });
       expect(onChangeAsLabelRow).toHaveBeenCalledWith("l1", {

--- a/src/Components/QueryConditionBuilder/TransformStepEditor.test.tsx
+++ b/src/Components/QueryConditionBuilder/TransformStepEditor.test.tsx
@@ -1,0 +1,298 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import TransformStepEditor from "./TransformStepEditor";
+import { RosTransformStep } from "../../Helpers/transformStepBuilder";
+
+const baseStep: RosTransformStep = {
+  sections: [],
+  topic: "",
+  encode: [],
+  asLabel: [],
+  export: { format: "", duration: "", size: "" },
+};
+
+const noopHandlers = {
+  onAddSection: vi.fn(),
+  onRemoveSection: vi.fn(),
+  onChangeTopic: vi.fn(),
+  onAddEncodeRow: vi.fn(),
+  onChangeEncodeRow: vi.fn(),
+  onRemoveEncodeRow: vi.fn(),
+  onAddAsLabelRow: vi.fn(),
+  onChangeAsLabelRow: vi.fn(),
+  onRemoveAsLabelRow: vi.fn(),
+  onChangeExport: vi.fn(),
+};
+
+describe("TransformStepEditor", () => {
+  it("shows only the Add option menu when no section is added", () => {
+    render(<TransformStepEditor step={baseStep} {...noopHandlers} />);
+    expect(screen.getByLabelText("Add option")).toBeTruthy();
+    expect(
+      screen.queryByPlaceholderText("optional ROS topic filter"),
+    ).toBeNull();
+  });
+
+  it("adds a section via the dropdown menu", async () => {
+    const onAddSection = vi.fn();
+    render(
+      <TransformStepEditor
+        step={baseStep}
+        {...noopHandlers}
+        onAddSection={onAddSection}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Add option"));
+    fireEvent.click(await screen.findByText("Filter"));
+    expect(onAddSection).toHaveBeenCalledWith("filter");
+  });
+
+  it("hides Export from the menu once Filter/Encode/Label is added, and vice versa", async () => {
+    const withFilter: RosTransformStep = {
+      ...baseStep,
+      sections: ["filter"],
+      topic: "/robot/odom",
+    };
+    render(<TransformStepEditor step={withFilter} {...noopHandlers} />);
+    fireEvent.click(screen.getByLabelText("Add option"));
+    expect(await screen.findByText("Encode")).toBeTruthy();
+    expect(screen.queryByText("Export")).toBeNull();
+  });
+
+  it("leaves no addable section once Export is added, since it's mutually exclusive with the other three", () => {
+    const withExport: RosTransformStep = {
+      ...baseStep,
+      sections: ["export"],
+      export: { format: "mcap", duration: "", size: "" },
+    };
+    render(<TransformStepEditor step={withExport} {...noopHandlers} />);
+    expect(screen.queryByLabelText("Add option")).toBeNull();
+  });
+
+  it("disables (but keeps visible) Add option once all four sections are added and no row is ready to duplicate", () => {
+    const step: RosTransformStep = {
+      ...baseStep,
+      sections: ["filter", "encode", "label", "export"],
+      encode: [{ id: "e1", key: "", value: "" }],
+      asLabel: [{ id: "l1", key: "", value: "" }],
+    };
+    render(<TransformStepEditor step={step} {...noopHandlers} />);
+    expect(screen.getByLabelText("Add option")).toBeDisabled();
+  });
+
+  describe("Filter section", () => {
+    const step: RosTransformStep = {
+      ...baseStep,
+      sections: ["filter"],
+      topic: "/robot/odom",
+    };
+
+    it("shows the current topic", () => {
+      render(<TransformStepEditor step={step} {...noopHandlers} />);
+      expect(
+        screen.getByPlaceholderText("optional ROS topic filter"),
+      ).toHaveValue("/robot/odom");
+    });
+
+    it("reports a typed topic", () => {
+      const onChangeTopic = vi.fn();
+      render(
+        <TransformStepEditor
+          step={step}
+          {...noopHandlers}
+          onChangeTopic={onChangeTopic}
+        />,
+      );
+      fireEvent.change(
+        screen.getByPlaceholderText("optional ROS topic filter"),
+        { target: { value: "/camera/image" } },
+      );
+      expect(onChangeTopic).toHaveBeenCalledWith("/camera/image");
+    });
+
+    it("removes the section via its remove button", () => {
+      const onRemoveSection = vi.fn();
+      render(
+        <TransformStepEditor
+          step={step}
+          {...noopHandlers}
+          onRemoveSection={onRemoveSection}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText("Remove filter"));
+      expect(onRemoveSection).toHaveBeenCalledWith("filter");
+    });
+  });
+
+  describe("Encode section", () => {
+    const step: RosTransformStep = {
+      ...baseStep,
+      sections: ["encode"],
+      encode: [{ id: "e1", key: "data", value: "jpeg" }],
+    };
+
+    it("renders a row and reports edits", () => {
+      const onChangeEncodeRow = vi.fn();
+      render(
+        <TransformStepEditor
+          step={step}
+          {...noopHandlers}
+          onChangeEncodeRow={onChangeEncodeRow}
+        />,
+      );
+      fireEvent.change(screen.getByPlaceholderText("field (e.g. data)"), {
+        target: { value: "image" },
+      });
+      expect(onChangeEncodeRow).toHaveBeenCalledWith("e1", { key: "image" });
+
+      fireEvent.change(screen.getByPlaceholderText("encoding (e.g. jpeg)"), {
+        target: { value: "base64" },
+      });
+      expect(onChangeEncodeRow).toHaveBeenCalledWith("e1", {
+        value: "base64",
+      });
+    });
+
+    it("removes the whole section when the only row's remove button is clicked", () => {
+      const onRemoveSection = vi.fn();
+      render(
+        <TransformStepEditor
+          step={step}
+          {...noopHandlers}
+          onRemoveSection={onRemoveSection}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText("Remove encode"));
+      expect(onRemoveSection).toHaveBeenCalledWith("encode");
+    });
+
+    it("offers Add encode row from the single Add option menu when the last row is complete", async () => {
+      const onAddEncodeRow = vi.fn();
+      render(
+        <TransformStepEditor
+          step={step}
+          {...noopHandlers}
+          onAddEncodeRow={onAddEncodeRow}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText("Add option"));
+      fireEvent.click(await screen.findByText("Add encode row"));
+      expect(onAddEncodeRow).toHaveBeenCalled();
+    });
+
+    it("omits Add encode row from the menu until the last row is complete", async () => {
+      const partial: RosTransformStep = {
+        ...baseStep,
+        sections: ["encode"],
+        encode: [{ id: "e1", key: "data", value: "" }],
+      };
+      render(<TransformStepEditor step={partial} {...noopHandlers} />);
+      fireEvent.click(screen.getByLabelText("Add option"));
+      expect(screen.queryByText("Add encode row")).toBeNull();
+    });
+  });
+
+  describe("Label section", () => {
+    const step: RosTransformStep = {
+      ...baseStep,
+      sections: ["label"],
+      asLabel: [{ id: "l1", key: "speed", value: "speed" }],
+    };
+
+    it("renders a row and reports edits", () => {
+      const onChangeAsLabelRow = vi.fn();
+      render(
+        <TransformStepEditor
+          step={step}
+          {...noopHandlers}
+          onChangeAsLabelRow={onChangeAsLabelRow}
+        />,
+      );
+      fireEvent.change(
+        screen.getByPlaceholderText("label name (e.g. label_name)"),
+        { target: { value: "velocity" } },
+      );
+      expect(onChangeAsLabelRow).toHaveBeenCalledWith("l1", {
+        key: "velocity",
+      });
+
+      fireEvent.change(screen.getByPlaceholderText("field (e.g. latitude)"), {
+        target: { value: "data.speed" },
+      });
+      expect(onChangeAsLabelRow).toHaveBeenCalledWith("l1", {
+        value: "data.speed",
+      });
+    });
+
+    it("calls onRemoveAsLabelRow with the row's id", () => {
+      const onRemoveAsLabelRow = vi.fn();
+      const twoRows: RosTransformStep = {
+        ...baseStep,
+        sections: ["label"],
+        asLabel: [
+          { id: "l1", key: "speed", value: "speed" },
+          { id: "l2", key: "accel", value: "accel" },
+        ],
+      };
+      render(
+        <TransformStepEditor
+          step={twoRows}
+          {...noopHandlers}
+          onRemoveAsLabelRow={onRemoveAsLabelRow}
+        />,
+      );
+      const [firstRemove] = screen.getAllByLabelText("Remove label mapping");
+      fireEvent.click(firstRemove);
+      expect(onRemoveAsLabelRow).toHaveBeenCalledWith("l1");
+    });
+
+    it("removes the whole section via its remove button", () => {
+      const onRemoveSection = vi.fn();
+      render(
+        <TransformStepEditor
+          step={step}
+          {...noopHandlers}
+          onRemoveSection={onRemoveSection}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText("Remove label"));
+      expect(onRemoveSection).toHaveBeenCalledWith("label");
+    });
+  });
+
+  describe("Export section", () => {
+    const step: RosTransformStep = {
+      ...baseStep,
+      sections: ["export"],
+      export: { format: "mcap", duration: "1m", size: "100MB" },
+    };
+
+    it("shows the current format, duration, and size", () => {
+      render(<TransformStepEditor step={step} {...noopHandlers} />);
+      expect(
+        screen.getByPlaceholderText("mcap (currently the only format)"),
+      ).toHaveValue("mcap");
+      expect(screen.getByPlaceholderText("max duration (e.g. 1m)")).toHaveValue(
+        "1m",
+      );
+      expect(screen.getByPlaceholderText("max size (e.g. 100MB)")).toHaveValue(
+        "100MB",
+      );
+    });
+
+    it("reports edits to each field", () => {
+      const onChangeExport = vi.fn();
+      render(
+        <TransformStepEditor
+          step={step}
+          {...noopHandlers}
+          onChangeExport={onChangeExport}
+        />,
+      );
+      fireEvent.change(screen.getByPlaceholderText("max duration (e.g. 1m)"), {
+        target: { value: "5m" },
+      });
+      expect(onChangeExport).toHaveBeenCalledWith({ duration: "5m" });
+    });
+  });
+});

--- a/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
@@ -7,6 +7,12 @@ import {
   RosSection,
   RosTransformStep,
 } from "../../Helpers/transformStepBuilder";
+import {
+  ROW_LABEL_WIDTH,
+  ROW_INPUT_WIDTH,
+  ROW_GAP,
+  ROW_GROUP_WIDTH,
+} from "./stepRowLayout";
 
 const SECTION_LABELS: Record<RosSection, string> = {
   filter: "Filter",
@@ -16,8 +22,6 @@ const SECTION_LABELS: Record<RosSection, string> = {
 };
 
 const ALL_SECTIONS: RosSection[] = ["filter", "encode", "label", "export"];
-
-const ROW_INPUT_WIDTH = 260;
 
 interface RowListProps {
   rows: KeyValueRow[];
@@ -50,20 +54,24 @@ function RowList({
       {rows.map((row) => (
         <div
           key={row.id}
-          style={{ display: "flex", alignItems: "center", gap: 8 }}
+          style={{ display: "flex", alignItems: "center", gap: ROW_GAP }}
         >
-          <Input
-            placeholder={keyPlaceholder}
-            value={row.key}
-            onChange={(e) => onChange(row.id, { key: e.target.value })}
-            style={{ width: ROW_INPUT_WIDTH }}
-          />
-          <Input
-            placeholder={valuePlaceholder}
-            value={row.value}
-            onChange={(e) => onChange(row.id, { value: e.target.value })}
-            style={{ width: ROW_INPUT_WIDTH }}
-          />
+          <div
+            style={{ display: "flex", gap: ROW_GAP, width: ROW_GROUP_WIDTH }}
+          >
+            <Input
+              placeholder={keyPlaceholder}
+              value={row.key}
+              onChange={(e) => onChange(row.id, { key: e.target.value })}
+              style={{ flex: 1, minWidth: 0 }}
+            />
+            <Input
+              placeholder={valuePlaceholder}
+              value={row.value}
+              onChange={(e) => onChange(row.id, { value: e.target.value })}
+              style={{ flex: 1, minWidth: 0 }}
+            />
+          </div>
           <Button
             aria-label={onlyRow ? sectionRemoveLabel : removeLabel}
             type="text"
@@ -124,7 +132,12 @@ function Section({
     <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
       <Typography.Text
         strong
-        style={{ width: 64, flexShrink: 0, paddingTop: 6, fontSize: 12 }}
+        style={{
+          width: ROW_LABEL_WIDTH,
+          flexShrink: 0,
+          paddingTop: 6,
+          fontSize: 12,
+        }}
       >
         {SECTION_LABELS[section]}
       </Typography.Text>
@@ -133,11 +146,29 @@ function Section({
   );
 }
 
-const ADD_ENCODE_ROW_KEY = "add_encode_row";
-const ADD_LABEL_ROW_KEY = "add_label_row";
+function disabledReason(
+  section: RosSection,
+  step: RosTransformStep,
+): string | undefined {
+  const hasExtractSection = step.sections.some(
+    (s) => s === "filter" || s === "encode" || s === "label",
+  );
+  const hasExportSection = step.sections.includes("export");
 
-function isRowComplete(row: KeyValueRow | undefined): boolean {
-  return !!row && row.key.trim() !== "" && row.value.trim() !== "";
+  if (section === "export") {
+    if (hasExportSection) return "Export is already added";
+    if (hasExtractSection)
+      return "Export can't be combined with Filter, Encode, or As label";
+    return undefined;
+  }
+  if (section === "filter") {
+    if (step.sections.includes("filter")) return "Filter is already added";
+    if (hasExportSection) return "Not available together with Export";
+    return undefined;
+  }
+  // encode / label: never "used up" - clicking again adds another row
+  if (hasExportSection) return "Not available together with Export";
+  return undefined;
 }
 
 export default function TransformStepEditor({
@@ -153,49 +184,31 @@ export default function TransformStepEditor({
   onRemoveAsLabelRow,
   onChangeExport,
 }: TransformStepEditorProps) {
-  // The server accepts only one of extract/export/transform per request, so
-  // Export can never coexist with Filter/Encode/Label (which all feed into
-  // extract) - confirmed by the server's own rejection message.
-  const hasExtractSection = step.sections.some(
-    (section) =>
-      section === "filter" || section === "encode" || section === "label",
-  );
-  const hasExportSection = step.sections.includes("export");
-  const availableSections = ALL_SECTIONS.filter((section) => {
-    if (step.sections.includes(section)) {
-      return false;
-    }
-    if (section === "export" && hasExtractSection) {
-      return false;
-    }
-    if (section !== "export" && hasExportSection) {
-      return false;
-    }
-    return true;
+  const menuItems = ALL_SECTIONS.map((section) => {
+    const reason = disabledReason(section, step);
+    return {
+      key: section,
+      disabled: !!reason,
+      label: reason ? (
+        <Tooltip title={reason} placement="right">
+          <span style={{ color: "rgba(0, 0, 0, 0.25)" }}>
+            {SECTION_LABELS[section]}
+          </span>
+        </Tooltip>
+      ) : (
+        SECTION_LABELS[section]
+      ),
+    };
   });
 
-  const menuItems = [
-    ...availableSections.map((section) => ({
-      key: section,
-      label: SECTION_LABELS[section],
-    })),
-    ...(step.sections.includes("encode") &&
-    isRowComplete(step.encode[step.encode.length - 1])
-      ? [{ key: ADD_ENCODE_ROW_KEY, label: "Add encode row" }]
-      : []),
-    ...(step.sections.includes("label") &&
-    isRowComplete(step.asLabel[step.asLabel.length - 1])
-      ? [{ key: ADD_LABEL_ROW_KEY, label: "Add label row" }]
-      : []),
-  ];
-
   const handleMenuClick = ({ key }: { key: string }) => {
-    if (key === ADD_ENCODE_ROW_KEY) {
+    const section = key as RosSection;
+    if (section === "encode" && step.sections.includes("encode")) {
       onAddEncodeRow();
-    } else if (key === ADD_LABEL_ROW_KEY) {
+    } else if (section === "label" && step.sections.includes("label")) {
       onAddAsLabelRow();
     } else {
-      onAddSection(key as RosSection);
+      onAddSection(section);
     }
   };
 
@@ -203,12 +216,12 @@ export default function TransformStepEditor({
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
       {step.sections.includes("filter") && (
         <Section section="filter">
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: ROW_GAP }}>
             <Input
               placeholder="optional ROS topic filter"
               value={step.topic}
               onChange={(e) => onChangeTopic(e.target.value)}
-              style={{ width: ROW_INPUT_WIDTH }}
+              style={{ width: ROW_GROUP_WIDTH }}
             />
             <RemoveSectionButton
               section="filter"
@@ -278,27 +291,15 @@ export default function TransformStepEditor({
       )}
 
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-        {(availableSections.length > 0 ||
-          step.sections.includes("encode") ||
-          step.sections.includes("label")) && (
-          <Tooltip
-            title={menuItems.length > 0 ? "" : "Fill in the current row first"}
-          >
-            <span style={{ display: "inline-block" }}>
-              <Dropdown
-                menu={{ items: menuItems, onClick: handleMenuClick }}
-                trigger={menuItems.length > 0 ? ["click"] : []}
-                disabled={menuItems.length === 0}
-              >
-                <Button
-                  aria-label="Add option"
-                  disabled={menuItems.length === 0}
-                  icon={<PlusOutlined style={{ transform: "scale(0.65)" }} />}
-                />
-              </Dropdown>
-            </span>
-          </Tooltip>
-        )}
+        <Dropdown
+          menu={{ items: menuItems, onClick: handleMenuClick }}
+          trigger={["click"]}
+        >
+          <Button
+            aria-label="Add option"
+            icon={<PlusOutlined style={{ transform: "scale(0.65)" }} />}
+          />
+        </Dropdown>
         <Typography.Text type="secondary" style={{ fontSize: 12 }}>
           <a
             href="https://www.reduct.store/docs/extensions/official/ros-ext"

--- a/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
@@ -237,7 +237,7 @@ export default function TransformStepEditor({
         <Section section="label">
           <RowList
             rows={step.asLabel}
-            keyPlaceholder="label name (e.g. label_name)"
+            keyPlaceholder="label name (e.g. lat_x)"
             valuePlaceholder="field (e.g. latitude.x)"
             onChange={onChangeAsLabelRow}
             onRemove={onRemoveAsLabelRow}

--- a/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
@@ -119,9 +119,14 @@ function Section({
   children: ReactNode;
 }) {
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-      <Typography.Text strong>{SECTION_LABELS[section]}</Typography.Text>
-      {children}
+    <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+      <Typography.Text
+        strong
+        style={{ width: 56, flexShrink: 0, paddingTop: 6 }}
+      >
+        {SECTION_LABELS[section]}
+      </Typography.Text>
+      <div style={{ flex: 1, minWidth: 0 }}>{children}</div>
     </div>
   );
 }
@@ -203,6 +208,12 @@ export default function TransformStepEditor({
               onChange={(e) => onChangeTopic(e.target.value)}
               style={{ flex: 1 }}
             />
+            <Input
+              aria-hidden="true"
+              tabIndex={-1}
+              disabled
+              style={{ flex: 1, visibility: "hidden" }}
+            />
             <RemoveSectionButton
               section="filter"
               onRemove={() => onRemoveSection("filter")}
@@ -270,27 +281,38 @@ export default function TransformStepEditor({
         </Section>
       )}
 
-      {(availableSections.length > 0 ||
-        step.sections.includes("encode") ||
-        step.sections.includes("label")) && (
-        <Tooltip
-          title={menuItems.length > 0 ? "" : "Fill in the current row first"}
-        >
-          <span style={{ display: "inline-block", alignSelf: "flex-start" }}>
-            <Dropdown
-              menu={{ items: menuItems, onClick: handleMenuClick }}
-              trigger={menuItems.length > 0 ? ["click"] : []}
-              disabled={menuItems.length === 0}
-            >
-              <Button
-                aria-label="Add option"
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          <a
+            href="https://www.reduct.store/docs/extensions/official/ros-ext"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <strong>View ReductROS Documentation →</strong>
+          </a>
+        </Typography.Text>
+        {(availableSections.length > 0 ||
+          step.sections.includes("encode") ||
+          step.sections.includes("label")) && (
+          <Tooltip
+            title={menuItems.length > 0 ? "" : "Fill in the current row first"}
+          >
+            <span style={{ display: "inline-block" }}>
+              <Dropdown
+                menu={{ items: menuItems, onClick: handleMenuClick }}
+                trigger={menuItems.length > 0 ? ["click"] : []}
                 disabled={menuItems.length === 0}
-                icon={<PlusOutlined style={{ transform: "scale(0.65)" }} />}
-              />
-            </Dropdown>
-          </span>
-        </Tooltip>
-      )}
+              >
+                <Button
+                  aria-label="Add option"
+                  disabled={menuItems.length === 0}
+                  icon={<PlusOutlined style={{ transform: "scale(0.65)" }} />}
+                />
+              </Dropdown>
+            </span>
+          </Tooltip>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, Fragment, ReactNode } from "react";
+import { ReactNode } from "react";
 import { Button, Dropdown, Input, Tooltip, Typography } from "antd";
 import { CloseOutlined, PlusOutlined } from "@ant-design/icons";
 import {
@@ -17,11 +17,9 @@ const SECTION_LABELS: Record<RosSection, string> = {
 
 const ALL_SECTIONS: RosSection[] = ["filter", "encode", "label", "export"];
 
-const ROW_GRID_TEMPLATE_COLUMNS = "64px 1fr 1fr auto";
-const SECTION_CONTENT_MAX_WIDTH = 640;
+const ROW_INPUT_WIDTH = 260;
 
 interface RowListProps {
-  sectionLabel: string;
   rows: KeyValueRow[];
   keyPlaceholder: string;
   valuePlaceholder: string;
@@ -35,8 +33,7 @@ interface RowListProps {
   sectionRemoveLabel: string;
 }
 
-function RowListGridItems({
-  sectionLabel,
+function RowList({
   rows,
   keyPlaceholder,
   valuePlaceholder,
@@ -49,27 +46,23 @@ function RowListGridItems({
   const onlyRow = rows.length === 1;
 
   return (
-    <>
-      {rows.map((row, index) => (
-        <Fragment key={row.id}>
-          {index === 0 ? (
-            <Typography.Text strong style={{ fontSize: 12 }}>
-              {sectionLabel}
-            </Typography.Text>
-          ) : (
-            <span />
-          )}
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {rows.map((row) => (
+        <div
+          key={row.id}
+          style={{ display: "flex", alignItems: "center", gap: 8 }}
+        >
           <Input
             placeholder={keyPlaceholder}
             value={row.key}
             onChange={(e) => onChange(row.id, { key: e.target.value })}
-            style={{ minWidth: 0 }}
+            style={{ width: ROW_INPUT_WIDTH }}
           />
           <Input
             placeholder={valuePlaceholder}
             value={row.value}
             onChange={(e) => onChange(row.id, { value: e.target.value })}
-            style={{ minWidth: 0 }}
+            style={{ width: ROW_INPUT_WIDTH }}
           />
           <Button
             aria-label={onlyRow ? sectionRemoveLabel : removeLabel}
@@ -77,9 +70,9 @@ function RowListGridItems({
             icon={<CloseOutlined style={{ transform: "scale(0.65)" }} />}
             onClick={() => (onlyRow ? onRemoveSection() : onRemove(row.id))}
           />
-        </Fragment>
+        </div>
       ))}
-    </>
+    </div>
   );
 }
 
@@ -106,11 +99,9 @@ interface TransformStepEditorProps {
 function RemoveSectionButton({
   section,
   onRemove,
-  style,
 }: {
   section: RosSection;
   onRemove: () => void;
-  style?: CSSProperties;
 }) {
   return (
     <Button
@@ -118,7 +109,6 @@ function RemoveSectionButton({
       type="text"
       icon={<CloseOutlined style={{ transform: "scale(0.65)" }} />}
       onClick={onRemove}
-      style={style}
     />
   );
 }
@@ -138,16 +128,7 @@ function Section({
       >
         {SECTION_LABELS[section]}
       </Typography.Text>
-      <div
-        style={{
-          flexGrow: 0,
-          flexShrink: 1,
-          width: SECTION_CONTENT_MAX_WIDTH,
-          minWidth: 0,
-        }}
-      >
-        {children}
-      </div>
+      {children}
     </div>
   );
 }
@@ -218,101 +199,75 @@ export default function TransformStepEditor({
     }
   };
 
-  const hasGridSection =
-    step.sections.includes("filter") ||
-    step.sections.includes("encode") ||
-    step.sections.includes("label");
-
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-      {hasGridSection && (
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: ROW_GRID_TEMPLATE_COLUMNS,
-            columnGap: 10,
-            rowGap: 12,
-            alignItems: "center",
-            maxWidth: SECTION_CONTENT_MAX_WIDTH + 64 + 10,
-          }}
-        >
-          {step.sections.includes("filter") && (
-            <>
-              <Typography.Text strong style={{ fontSize: 12 }}>
-                {SECTION_LABELS.filter}
-              </Typography.Text>
-              <Input
-                placeholder="optional ROS topic filter"
-                value={step.topic}
-                onChange={(e) => onChangeTopic(e.target.value)}
-                style={{ minWidth: 0 }}
-              />
-              <RemoveSectionButton
-                section="filter"
-                onRemove={() => onRemoveSection("filter")}
-                style={{ justifySelf: "start" }}
-              />
-              <span />
-            </>
-          )}
-
-          {step.sections.includes("encode") && (
-            <RowListGridItems
-              sectionLabel={SECTION_LABELS.encode}
-              rows={step.encode}
-              keyPlaceholder="field (e.g. data)"
-              valuePlaceholder="encoding (e.g. jpeg)"
-              onChange={onChangeEncodeRow}
-              onRemove={onRemoveEncodeRow}
-              removeLabel="Remove encode mapping"
-              onRemoveSection={() => onRemoveSection("encode")}
-              sectionRemoveLabel={`Remove ${SECTION_LABELS.encode.toLowerCase()}`}
+      {step.sections.includes("filter") && (
+        <Section section="filter">
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <Input
+              placeholder="optional ROS topic filter"
+              value={step.topic}
+              onChange={(e) => onChangeTopic(e.target.value)}
+              style={{ width: ROW_INPUT_WIDTH }}
             />
-          )}
-
-          {step.sections.includes("label") && (
-            <RowListGridItems
-              sectionLabel={SECTION_LABELS.label}
-              rows={step.asLabel}
-              keyPlaceholder="label name (e.g. label_name)"
-              valuePlaceholder="field (e.g. latitude)"
-              onChange={onChangeAsLabelRow}
-              onRemove={onRemoveAsLabelRow}
-              removeLabel="Remove label mapping"
-              onRemoveSection={() => onRemoveSection("label")}
-              sectionRemoveLabel={`Remove ${SECTION_LABELS.label.toLowerCase()}`}
+            <RemoveSectionButton
+              section="filter"
+              onRemove={() => onRemoveSection("filter")}
             />
-          )}
-        </div>
+          </div>
+        </Section>
+      )}
+
+      {step.sections.includes("encode") && (
+        <Section section="encode">
+          <RowList
+            rows={step.encode}
+            keyPlaceholder="field (e.g. data)"
+            valuePlaceholder="encoding (e.g. jpeg)"
+            onChange={onChangeEncodeRow}
+            onRemove={onRemoveEncodeRow}
+            removeLabel="Remove encode mapping"
+            onRemoveSection={() => onRemoveSection("encode")}
+            sectionRemoveLabel={`Remove ${SECTION_LABELS.encode.toLowerCase()}`}
+          />
+        </Section>
+      )}
+
+      {step.sections.includes("label") && (
+        <Section section="label">
+          <RowList
+            rows={step.asLabel}
+            keyPlaceholder="label name (e.g. label_name)"
+            valuePlaceholder="field (e.g. latitude)"
+            onChange={onChangeAsLabelRow}
+            onRemove={onRemoveAsLabelRow}
+            removeLabel="Remove label mapping"
+            onRemoveSection={() => onRemoveSection("label")}
+            sectionRemoveLabel={`Remove ${SECTION_LABELS.label.toLowerCase()}`}
+          />
+        </Section>
       )}
 
       {step.sections.includes("export") && (
         <Section section="export">
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              minWidth: 0,
-            }}
-          >
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
             <Input
               placeholder="mcap (currently the only format)"
               value={step.export.format}
               onChange={(e) => onChangeExport({ format: e.target.value })}
-              style={{ flex: 1, minWidth: 0 }}
+              style={{ width: ROW_INPUT_WIDTH }}
             />
             <Input
               placeholder="max duration (e.g. 1m)"
               value={step.export.duration}
               onChange={(e) => onChangeExport({ duration: e.target.value })}
-              style={{ flex: 1, minWidth: 0 }}
+              style={{ width: ROW_INPUT_WIDTH }}
             />
             <Input
               placeholder="max size (e.g. 100MB)"
               value={step.export.size}
               onChange={(e) => onChangeExport({ size: e.target.value })}
-              style={{ flex: 1, minWidth: 0 }}
+              style={{ width: ROW_INPUT_WIDTH }}
             />
             <RemoveSectionButton
               section="export"

--- a/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
@@ -1,0 +1,296 @@
+import { ReactNode } from "react";
+import { Button, Dropdown, Input, Tooltip, Typography } from "antd";
+import { CloseOutlined, PlusOutlined } from "@ant-design/icons";
+import {
+  KeyValueRow,
+  RosExportConfig,
+  RosSection,
+  RosTransformStep,
+} from "../../Helpers/transformStepBuilder";
+
+const SECTION_LABELS: Record<RosSection, string> = {
+  filter: "Filter",
+  encode: "Encode",
+  label: "Label",
+  export: "Export",
+};
+
+const ALL_SECTIONS: RosSection[] = ["filter", "encode", "label", "export"];
+
+interface RowListProps {
+  rows: KeyValueRow[];
+  keyPlaceholder: string;
+  valuePlaceholder: string;
+  onChange: (
+    id: string,
+    changes: Partial<Pick<KeyValueRow, "key" | "value">>,
+  ) => void;
+  onRemove: (id: string) => void;
+  removeLabel: string;
+  onRemoveSection: () => void;
+  sectionRemoveLabel: string;
+}
+
+function RowList({
+  rows,
+  keyPlaceholder,
+  valuePlaceholder,
+  onChange,
+  onRemove,
+  removeLabel,
+  onRemoveSection,
+  sectionRemoveLabel,
+}: RowListProps) {
+  const onlyRow = rows.length === 1;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {rows.map((row) => (
+        <div
+          key={row.id}
+          style={{ display: "flex", alignItems: "center", gap: 8 }}
+        >
+          <Input
+            placeholder={keyPlaceholder}
+            value={row.key}
+            onChange={(e) => onChange(row.id, { key: e.target.value })}
+            style={{ flex: 1 }}
+          />
+          <Input
+            placeholder={valuePlaceholder}
+            value={row.value}
+            onChange={(e) => onChange(row.id, { value: e.target.value })}
+            style={{ flex: 1 }}
+          />
+          <Button
+            aria-label={onlyRow ? sectionRemoveLabel : removeLabel}
+            type="text"
+            icon={<CloseOutlined style={{ transform: "scale(0.65)" }} />}
+            onClick={() => (onlyRow ? onRemoveSection() : onRemove(row.id))}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface TransformStepEditorProps {
+  step: RosTransformStep;
+  onAddSection: (section: RosSection) => void;
+  onRemoveSection: (section: RosSection) => void;
+  onChangeTopic: (topic: string) => void;
+  onAddEncodeRow: () => void;
+  onChangeEncodeRow: (
+    id: string,
+    changes: Partial<Pick<KeyValueRow, "key" | "value">>,
+  ) => void;
+  onRemoveEncodeRow: (id: string) => void;
+  onAddAsLabelRow: () => void;
+  onChangeAsLabelRow: (
+    id: string,
+    changes: Partial<Pick<KeyValueRow, "key" | "value">>,
+  ) => void;
+  onRemoveAsLabelRow: (id: string) => void;
+  onChangeExport: (changes: Partial<RosExportConfig>) => void;
+}
+
+function RemoveSectionButton({
+  section,
+  onRemove,
+}: {
+  section: RosSection;
+  onRemove: () => void;
+}) {
+  return (
+    <Button
+      aria-label={`Remove ${SECTION_LABELS[section].toLowerCase()}`}
+      type="text"
+      icon={<CloseOutlined style={{ transform: "scale(0.65)" }} />}
+      onClick={onRemove}
+    />
+  );
+}
+
+function Section({
+  section,
+  children,
+}: {
+  section: RosSection;
+  children: ReactNode;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <Typography.Text strong>{SECTION_LABELS[section]}</Typography.Text>
+      {children}
+    </div>
+  );
+}
+
+const ADD_ENCODE_ROW_KEY = "add_encode_row";
+const ADD_LABEL_ROW_KEY = "add_label_row";
+
+function isRowComplete(row: KeyValueRow | undefined): boolean {
+  return !!row && row.key.trim() !== "" && row.value.trim() !== "";
+}
+
+export default function TransformStepEditor({
+  step,
+  onAddSection,
+  onRemoveSection,
+  onChangeTopic,
+  onAddEncodeRow,
+  onChangeEncodeRow,
+  onRemoveEncodeRow,
+  onAddAsLabelRow,
+  onChangeAsLabelRow,
+  onRemoveAsLabelRow,
+  onChangeExport,
+}: TransformStepEditorProps) {
+  // The server accepts only one of extract/export/transform per request, so
+  // Export can never coexist with Filter/Encode/Label (which all feed into
+  // extract) - confirmed by the server's own rejection message.
+  const hasExtractSection = step.sections.some(
+    (section) =>
+      section === "filter" || section === "encode" || section === "label",
+  );
+  const hasExportSection = step.sections.includes("export");
+  const availableSections = ALL_SECTIONS.filter((section) => {
+    if (step.sections.includes(section)) {
+      return false;
+    }
+    if (section === "export" && hasExtractSection) {
+      return false;
+    }
+    if (section !== "export" && hasExportSection) {
+      return false;
+    }
+    return true;
+  });
+
+  const menuItems = [
+    ...availableSections.map((section) => ({
+      key: section,
+      label: SECTION_LABELS[section],
+    })),
+    ...(step.sections.includes("encode") &&
+    isRowComplete(step.encode[step.encode.length - 1])
+      ? [{ key: ADD_ENCODE_ROW_KEY, label: "Add encode row" }]
+      : []),
+    ...(step.sections.includes("label") &&
+    isRowComplete(step.asLabel[step.asLabel.length - 1])
+      ? [{ key: ADD_LABEL_ROW_KEY, label: "Add label row" }]
+      : []),
+  ];
+
+  const handleMenuClick = ({ key }: { key: string }) => {
+    if (key === ADD_ENCODE_ROW_KEY) {
+      onAddEncodeRow();
+    } else if (key === ADD_LABEL_ROW_KEY) {
+      onAddAsLabelRow();
+    } else {
+      onAddSection(key as RosSection);
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      {step.sections.includes("filter") && (
+        <Section section="filter">
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <Input
+              placeholder="optional ROS topic filter"
+              value={step.topic}
+              onChange={(e) => onChangeTopic(e.target.value)}
+              style={{ flex: 1 }}
+            />
+            <RemoveSectionButton
+              section="filter"
+              onRemove={() => onRemoveSection("filter")}
+            />
+          </div>
+        </Section>
+      )}
+
+      {step.sections.includes("encode") && (
+        <Section section="encode">
+          <RowList
+            rows={step.encode}
+            keyPlaceholder="field (e.g. data)"
+            valuePlaceholder="encoding (e.g. jpeg)"
+            onChange={onChangeEncodeRow}
+            onRemove={onRemoveEncodeRow}
+            removeLabel="Remove encode mapping"
+            onRemoveSection={() => onRemoveSection("encode")}
+            sectionRemoveLabel={`Remove ${SECTION_LABELS.encode.toLowerCase()}`}
+          />
+        </Section>
+      )}
+
+      {step.sections.includes("label") && (
+        <Section section="label">
+          <RowList
+            rows={step.asLabel}
+            keyPlaceholder="label name (e.g. label_name)"
+            valuePlaceholder="field (e.g. latitude)"
+            onChange={onChangeAsLabelRow}
+            onRemove={onRemoveAsLabelRow}
+            removeLabel="Remove label mapping"
+            onRemoveSection={() => onRemoveSection("label")}
+            sectionRemoveLabel={`Remove ${SECTION_LABELS.label.toLowerCase()}`}
+          />
+        </Section>
+      )}
+
+      {step.sections.includes("export") && (
+        <Section section="export">
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <Input
+              placeholder="mcap (currently the only format)"
+              value={step.export.format}
+              onChange={(e) => onChangeExport({ format: e.target.value })}
+              style={{ flex: 1 }}
+            />
+            <Input
+              placeholder="max duration (e.g. 1m)"
+              value={step.export.duration}
+              onChange={(e) => onChangeExport({ duration: e.target.value })}
+              style={{ flex: 1 }}
+            />
+            <Input
+              placeholder="max size (e.g. 100MB)"
+              value={step.export.size}
+              onChange={(e) => onChangeExport({ size: e.target.value })}
+              style={{ flex: 1 }}
+            />
+            <RemoveSectionButton
+              section="export"
+              onRemove={() => onRemoveSection("export")}
+            />
+          </div>
+        </Section>
+      )}
+
+      {(availableSections.length > 0 ||
+        step.sections.includes("encode") ||
+        step.sections.includes("label")) && (
+        <Tooltip
+          title={menuItems.length > 0 ? "" : "Fill in the current row first"}
+        >
+          <span style={{ display: "inline-block", alignSelf: "flex-start" }}>
+            <Dropdown
+              menu={{ items: menuItems, onClick: handleMenuClick }}
+              trigger={menuItems.length > 0 ? ["click"] : []}
+              disabled={menuItems.length === 0}
+            >
+              <Button
+                aria-label="Add option"
+                disabled={menuItems.length === 0}
+                icon={<PlusOutlined style={{ transform: "scale(0.65)" }} />}
+              />
+            </Dropdown>
+          </span>
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { CSSProperties, Fragment, ReactNode } from "react";
 import { Button, Dropdown, Input, Tooltip, Typography } from "antd";
 import { CloseOutlined, PlusOutlined } from "@ant-design/icons";
 import {
@@ -11,13 +11,17 @@ import {
 const SECTION_LABELS: Record<RosSection, string> = {
   filter: "Filter",
   encode: "Encode",
-  label: "Label",
+  label: "As label",
   export: "Export",
 };
 
 const ALL_SECTIONS: RosSection[] = ["filter", "encode", "label", "export"];
 
+const ROW_GRID_TEMPLATE_COLUMNS = "64px 1fr 1fr auto";
+const SECTION_CONTENT_MAX_WIDTH = 640;
+
 interface RowListProps {
+  sectionLabel: string;
   rows: KeyValueRow[];
   keyPlaceholder: string;
   valuePlaceholder: string;
@@ -31,7 +35,8 @@ interface RowListProps {
   sectionRemoveLabel: string;
 }
 
-function RowList({
+function RowListGridItems({
+  sectionLabel,
   rows,
   keyPlaceholder,
   valuePlaceholder,
@@ -44,23 +49,27 @@ function RowList({
   const onlyRow = rows.length === 1;
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-      {rows.map((row) => (
-        <div
-          key={row.id}
-          style={{ display: "flex", alignItems: "center", gap: 8 }}
-        >
+    <>
+      {rows.map((row, index) => (
+        <Fragment key={row.id}>
+          {index === 0 ? (
+            <Typography.Text strong style={{ fontSize: 12 }}>
+              {sectionLabel}
+            </Typography.Text>
+          ) : (
+            <span />
+          )}
           <Input
             placeholder={keyPlaceholder}
             value={row.key}
             onChange={(e) => onChange(row.id, { key: e.target.value })}
-            style={{ flex: 1 }}
+            style={{ minWidth: 0 }}
           />
           <Input
             placeholder={valuePlaceholder}
             value={row.value}
             onChange={(e) => onChange(row.id, { value: e.target.value })}
-            style={{ flex: 1 }}
+            style={{ minWidth: 0 }}
           />
           <Button
             aria-label={onlyRow ? sectionRemoveLabel : removeLabel}
@@ -68,9 +77,9 @@ function RowList({
             icon={<CloseOutlined style={{ transform: "scale(0.65)" }} />}
             onClick={() => (onlyRow ? onRemoveSection() : onRemove(row.id))}
           />
-        </div>
+        </Fragment>
       ))}
-    </div>
+    </>
   );
 }
 
@@ -97,9 +106,11 @@ interface TransformStepEditorProps {
 function RemoveSectionButton({
   section,
   onRemove,
+  style,
 }: {
   section: RosSection;
   onRemove: () => void;
+  style?: CSSProperties;
 }) {
   return (
     <Button
@@ -107,6 +118,7 @@ function RemoveSectionButton({
       type="text"
       icon={<CloseOutlined style={{ transform: "scale(0.65)" }} />}
       onClick={onRemove}
+      style={style}
     />
   );
 }
@@ -122,11 +134,20 @@ function Section({
     <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
       <Typography.Text
         strong
-        style={{ width: 56, flexShrink: 0, paddingTop: 6 }}
+        style={{ width: 64, flexShrink: 0, paddingTop: 6, fontSize: 12 }}
       >
         {SECTION_LABELS[section]}
       </Typography.Text>
-      <div style={{ flex: 1, minWidth: 0 }}>{children}</div>
+      <div
+        style={{
+          flexGrow: 0,
+          flexShrink: 1,
+          width: SECTION_CONTENT_MAX_WIDTH,
+          minWidth: 0,
+        }}
+      >
+        {children}
+      </div>
     </div>
   );
 }
@@ -197,81 +218,101 @@ export default function TransformStepEditor({
     }
   };
 
+  const hasGridSection =
+    step.sections.includes("filter") ||
+    step.sections.includes("encode") ||
+    step.sections.includes("label");
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-      {step.sections.includes("filter") && (
-        <Section section="filter">
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <Input
-              placeholder="optional ROS topic filter"
-              value={step.topic}
-              onChange={(e) => onChangeTopic(e.target.value)}
-              style={{ flex: 1 }}
-            />
-            <Input
-              aria-hidden="true"
-              tabIndex={-1}
-              disabled
-              style={{ flex: 1, visibility: "hidden" }}
-            />
-            <RemoveSectionButton
-              section="filter"
-              onRemove={() => onRemoveSection("filter")}
-            />
-          </div>
-        </Section>
-      )}
+      {hasGridSection && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: ROW_GRID_TEMPLATE_COLUMNS,
+            columnGap: 10,
+            rowGap: 12,
+            alignItems: "center",
+            maxWidth: SECTION_CONTENT_MAX_WIDTH + 64 + 10,
+          }}
+        >
+          {step.sections.includes("filter") && (
+            <>
+              <Typography.Text strong style={{ fontSize: 12 }}>
+                {SECTION_LABELS.filter}
+              </Typography.Text>
+              <Input
+                placeholder="optional ROS topic filter"
+                value={step.topic}
+                onChange={(e) => onChangeTopic(e.target.value)}
+                style={{ minWidth: 0 }}
+              />
+              <RemoveSectionButton
+                section="filter"
+                onRemove={() => onRemoveSection("filter")}
+                style={{ justifySelf: "start" }}
+              />
+              <span />
+            </>
+          )}
 
-      {step.sections.includes("encode") && (
-        <Section section="encode">
-          <RowList
-            rows={step.encode}
-            keyPlaceholder="field (e.g. data)"
-            valuePlaceholder="encoding (e.g. jpeg)"
-            onChange={onChangeEncodeRow}
-            onRemove={onRemoveEncodeRow}
-            removeLabel="Remove encode mapping"
-            onRemoveSection={() => onRemoveSection("encode")}
-            sectionRemoveLabel={`Remove ${SECTION_LABELS.encode.toLowerCase()}`}
-          />
-        </Section>
-      )}
+          {step.sections.includes("encode") && (
+            <RowListGridItems
+              sectionLabel={SECTION_LABELS.encode}
+              rows={step.encode}
+              keyPlaceholder="field (e.g. data)"
+              valuePlaceholder="encoding (e.g. jpeg)"
+              onChange={onChangeEncodeRow}
+              onRemove={onRemoveEncodeRow}
+              removeLabel="Remove encode mapping"
+              onRemoveSection={() => onRemoveSection("encode")}
+              sectionRemoveLabel={`Remove ${SECTION_LABELS.encode.toLowerCase()}`}
+            />
+          )}
 
-      {step.sections.includes("label") && (
-        <Section section="label">
-          <RowList
-            rows={step.asLabel}
-            keyPlaceholder="label name (e.g. label_name)"
-            valuePlaceholder="field (e.g. latitude)"
-            onChange={onChangeAsLabelRow}
-            onRemove={onRemoveAsLabelRow}
-            removeLabel="Remove label mapping"
-            onRemoveSection={() => onRemoveSection("label")}
-            sectionRemoveLabel={`Remove ${SECTION_LABELS.label.toLowerCase()}`}
-          />
-        </Section>
+          {step.sections.includes("label") && (
+            <RowListGridItems
+              sectionLabel={SECTION_LABELS.label}
+              rows={step.asLabel}
+              keyPlaceholder="label name (e.g. label_name)"
+              valuePlaceholder="field (e.g. latitude)"
+              onChange={onChangeAsLabelRow}
+              onRemove={onRemoveAsLabelRow}
+              removeLabel="Remove label mapping"
+              onRemoveSection={() => onRemoveSection("label")}
+              sectionRemoveLabel={`Remove ${SECTION_LABELS.label.toLowerCase()}`}
+            />
+          )}
+        </div>
       )}
 
       {step.sections.includes("export") && (
         <Section section="export">
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              minWidth: 0,
+            }}
+          >
             <Input
               placeholder="mcap (currently the only format)"
               value={step.export.format}
               onChange={(e) => onChangeExport({ format: e.target.value })}
-              style={{ flex: 1 }}
+              style={{ flex: 1, minWidth: 0 }}
             />
             <Input
               placeholder="max duration (e.g. 1m)"
               value={step.export.duration}
               onChange={(e) => onChangeExport({ duration: e.target.value })}
-              style={{ flex: 1 }}
+              style={{ flex: 1, minWidth: 0 }}
             />
             <Input
               placeholder="max size (e.g. 100MB)"
               value={step.export.size}
               onChange={(e) => onChangeExport({ size: e.target.value })}
-              style={{ flex: 1 }}
+              style={{ flex: 1, minWidth: 0 }}
             />
             <RemoveSectionButton
               section="export"
@@ -281,16 +322,7 @@ export default function TransformStepEditor({
         </Section>
       )}
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          <a
-            href="https://www.reduct.store/docs/extensions/official/ros-ext"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <strong>View ReductROS Documentation →</strong>
-          </a>
-        </Typography.Text>
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         {(availableSections.length > 0 ||
           step.sections.includes("encode") ||
           step.sections.includes("label")) && (
@@ -312,6 +344,15 @@ export default function TransformStepEditor({
             </span>
           </Tooltip>
         )}
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          <a
+            href="https://www.reduct.store/docs/extensions/official/ros-ext"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <strong>View ReductROS Documentation →</strong>
+          </a>
+        </Typography.Text>
       </div>
     </div>
   );

--- a/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
+++ b/src/Components/QueryConditionBuilder/TransformStepEditor.tsx
@@ -238,7 +238,7 @@ export default function TransformStepEditor({
           <RowList
             rows={step.asLabel}
             keyPlaceholder="label name (e.g. label_name)"
-            valuePlaceholder="field (e.g. latitude)"
+            valuePlaceholder="field (e.g. latitude.x)"
             onChange={onChangeAsLabelRow}
             onRemove={onRemoveAsLabelRow}
             removeLabel="Remove label mapping"

--- a/src/Components/QueryConditionBuilder/stepRowLayout.ts
+++ b/src/Components/QueryConditionBuilder/stepRowLayout.ts
@@ -1,4 +1,4 @@
-export const ROW_LABEL_WIDTH = 90;
+export const ROW_LABEL_WIDTH = 70;
 export const ROW_INPUT_WIDTH = 260;
 export const ROW_GAP = 8;
 export const ROW_GROUP_WIDTH = ROW_INPUT_WIDTH * 2 + ROW_GAP;

--- a/src/Components/QueryConditionBuilder/stepRowLayout.ts
+++ b/src/Components/QueryConditionBuilder/stepRowLayout.ts
@@ -2,3 +2,4 @@ export const ROW_LABEL_WIDTH = 70;
 export const ROW_INPUT_WIDTH = 260;
 export const ROW_GAP = 8;
 export const ROW_GROUP_WIDTH = ROW_INPUT_WIDTH * 2 + ROW_GAP;
+export const VALUE_INPUT_WIDTH = 100;

--- a/src/Components/QueryConditionBuilder/stepRowLayout.ts
+++ b/src/Components/QueryConditionBuilder/stepRowLayout.ts
@@ -1,0 +1,4 @@
+export const ROW_LABEL_WIDTH = 90;
+export const ROW_INPUT_WIDTH = 260;
+export const ROW_GAP = 8;
+export const ROW_GROUP_WIDTH = ROW_INPUT_WIDTH * 2 + ROW_GAP;

--- a/src/Components/QueryPanel/QueryPanel.tsx
+++ b/src/Components/QueryPanel/QueryPanel.tsx
@@ -452,6 +452,7 @@ export default function QueryPanel({
     linkOptions.head = false;
     linkOptions.strict = options.strict;
     linkOptions.when = options.when;
+    linkOptions.ext = options.ext;
     return linkOptions;
   };
 
@@ -631,6 +632,7 @@ export default function QueryPanel({
       selectedEntries,
       selectedEntryQuery,
       timeRange.end,
+      timeRange.start,
       whenCondition,
     ],
   );

--- a/src/Components/QueryPanel/QueryPanel.tsx
+++ b/src/Components/QueryPanel/QueryPanel.tsx
@@ -1122,9 +1122,8 @@ export default function QueryPanel({
     [selectedEntries],
   );
   const validationIntervalValue = useMemo(
-    () =>
-      timeRange.interval ?? pickEachTInterval(timeRange.start, timeRange.end),
-    [timeRange.end, timeRange.interval, timeRange.start],
+    () => pickEachTInterval(timeRange.start, timeRange.end),
+    [timeRange.end, timeRange.start],
   );
 
   return (

--- a/src/Components/QueryPanel/QueryPanel.tsx
+++ b/src/Components/QueryPanel/QueryPanel.tsx
@@ -530,11 +530,20 @@ export default function QueryPanel({
             return;
           }
 
-          const each_t = extractIntervalFromCondition(
-            conditionResult.processedCondition,
-          );
+          const { "#ext": ext, ...whenFields } =
+            (conditionResult.processedCondition ?? {}) as Record<
+              string,
+              unknown
+            >;
+
+          const each_t = extractIntervalFromCondition(whenFields);
           setTimeRangeState((prev) => ({ ...prev, interval: each_t }));
-          options.when = conditionResult.processedCondition;
+          if (Object.keys(whenFields).length > 0) {
+            options.when = whenFields;
+          }
+          if (ext !== undefined) {
+            options.ext = ext as Record<string, unknown>;
+          }
         }
 
         setQueryContext({
@@ -622,7 +631,6 @@ export default function QueryPanel({
       selectedEntries,
       selectedEntryQuery,
       timeRange.end,
-      timeRange.start,
       whenCondition,
     ],
   );

--- a/src/Helpers/conditionalQueryBuilder.ts
+++ b/src/Helpers/conditionalQueryBuilder.ts
@@ -49,13 +49,13 @@ export interface LimitStepEntry {
 // $each_n and $each_t are independent directives - a query can combine
 // both (e.g. thin to every 20th record, then also throttle to at most one
 // per second) - so each gets its own step, exactly like $limit, added and
-// removed independently from the "+ Add step" menu (as "Sample by time
-// interval" / "Sample every N records").
+// removed independently from the "+ Add step" menu (as "Sample by time" /
+// "Sample every N").
 export type Step = EachNStepEntry | EachTStepEntry | LimitStepEntry;
 
 export type SampleKind = "each_n" | "each_t";
 
-// Fixed id for the "Where labels" block in a QueryConditionBuilder's
+// Fixed id for the "Label filter" block in a QueryConditionBuilder's
 // blockOrder - shared so QueryConditionBuilder.tsx and QueryBlockList.tsx
 // can't drift apart on what it's called.
 export const CONDITIONS_BLOCK_ID = "conditions";

--- a/src/Helpers/transformStepBuilder.test.ts
+++ b/src/Helpers/transformStepBuilder.test.ts
@@ -259,6 +259,12 @@ describe("transformStepBuilder", () => {
         ros: { export: { duration: "1m" } },
       });
     });
+
+    it("keeps an empty ros.export when the section is present but every field is blank", () => {
+      let transform = addSection(createRosTransformStep(), "export");
+      transform = updateExport(transform, { format: "" });
+      expect(buildExtPayload(transform)).toEqual({ ros: { export: {} } });
+    });
   });
 
   describe("parseExtPayload", () => {
@@ -275,10 +281,22 @@ describe("transformStepBuilder", () => {
       expect(parseExtPayload({}).success).toBe(false);
     });
 
+    it("rejects an array in place of ros, extract, or export", () => {
+      expect(parseExtPayload({ ros: [] }).success).toBe(false);
+      expect(parseExtPayload({ ros: { extract: [] } }).success).toBe(false);
+      expect(parseExtPayload({ ros: { export: [] } }).success).toBe(false);
+    });
+
     it("succeeds with an empty extract and no sections", () => {
       const result = parseExtPayload({ ros: { extract: {} } });
       expect(result.success).toBe(true);
       expect(result.transform?.ros.sections).toEqual([]);
+    });
+
+    it("parses an empty export object into the export section", () => {
+      const result = parseExtPayload({ ros: { export: {} } });
+      expect(result.success).toBe(true);
+      expect(result.transform?.ros.sections).toEqual(["export"]);
     });
 
     it("parses topic into the filter section", () => {

--- a/src/Helpers/transformStepBuilder.test.ts
+++ b/src/Helpers/transformStepBuilder.test.ts
@@ -1,0 +1,360 @@
+import {
+  addAsLabelRow,
+  addEncodeRow,
+  addSection,
+  buildExtPayload,
+  createRosTransformStep,
+  hasIncompleteTransform,
+  parseExtPayload,
+  removeAsLabelRow,
+  removeEncodeRow,
+  removeSection,
+  TransformStepEntry,
+  updateAsLabelRow,
+  updateEncodeRow,
+  updateExport,
+  updateTopic,
+} from "./transformStepBuilder";
+
+describe("transformStepBuilder", () => {
+  describe("createRosTransformStep", () => {
+    it("defaults to no sections and blank fields", () => {
+      const transform = createRosTransformStep();
+      expect(transform.kind).toBe("ros");
+      expect(transform.ros.sections).toEqual([]);
+      expect(transform.ros.topic).toBe("");
+      expect(transform.ros.encode).toEqual([]);
+      expect(transform.ros.asLabel).toEqual([]);
+      expect(transform.ros.export).toEqual({
+        format: "",
+        duration: "",
+        size: "",
+      });
+    });
+  });
+
+  describe("addSection / removeSection", () => {
+    it("adds a section and seeds encode/label with one blank row", () => {
+      const transform = createRosTransformStep();
+      const withEncode = addSection(transform, "encode");
+      expect(withEncode.ros.sections).toEqual(["encode"]);
+      expect(withEncode.ros.encode).toHaveLength(1);
+      expect(withEncode.ros.encode[0]).toMatchObject({ key: "", value: "" });
+
+      const withLabel = addSection(withEncode, "label");
+      expect(withLabel.ros.sections).toEqual(["encode", "label"]);
+      expect(withLabel.ros.asLabel).toHaveLength(1);
+    });
+
+    it("adding filter or export seeds no rows", () => {
+      const transform = addSection(createRosTransformStep(), "filter");
+      expect(transform.ros.sections).toEqual(["filter"]);
+      expect(transform.ros.encode).toEqual([]);
+      expect(transform.ros.asLabel).toEqual([]);
+    });
+
+    it("is a no-op if the section is already present", () => {
+      const transform = addSection(createRosTransformStep(), "filter");
+      const again = addSection(transform, "filter");
+      expect(again).toBe(transform);
+    });
+
+    it("removes a section", () => {
+      const transform = addSection(createRosTransformStep(), "filter");
+      const result = removeSection(transform, "filter");
+      expect(result.ros.sections).toEqual([]);
+    });
+
+    it("adding export defaults format to mcap, the only supported value", () => {
+      const transform = addSection(createRosTransformStep(), "export");
+      expect(transform.ros.export.format).toBe("mcap");
+    });
+
+    it("does not override an already-set export format when re-added", () => {
+      let transform = addSection(createRosTransformStep(), "export");
+      transform = updateExport(transform, { format: "custom" });
+      transform = removeSection(transform, "export");
+      transform = addSection(transform, "export");
+      expect(transform.ros.export.format).toBe("custom");
+    });
+  });
+
+  describe("updateTopic", () => {
+    it("updates the topic", () => {
+      const transform = createRosTransformStep();
+      const result = updateTopic(transform, "/robot/odom");
+      expect(result.ros.topic).toBe("/robot/odom");
+    });
+  });
+
+  describe("updateExport", () => {
+    it("merges partial changes into the export config", () => {
+      const transform = createRosTransformStep();
+      const result = updateExport(transform, { duration: "1m" });
+      expect(result.ros.export).toEqual({
+        format: "",
+        duration: "1m",
+        size: "",
+      });
+    });
+  });
+
+  describe("encode rows", () => {
+    it("adds, updates, and removes rows", () => {
+      const transform = addSection(createRosTransformStep(), "encode");
+      const [first] = transform.ros.encode;
+
+      const withTwo = addEncodeRow(transform);
+      expect(withTwo.ros.encode).toHaveLength(2);
+
+      const updated = updateEncodeRow(withTwo, first.id, {
+        key: "data",
+        value: "jpeg",
+      });
+      expect(updated.ros.encode[0]).toMatchObject({
+        key: "data",
+        value: "jpeg",
+      });
+
+      const removed = removeEncodeRow(updated, first.id);
+      expect(removed.ros.encode).toHaveLength(1);
+      expect(removed.ros.encode[0].id).not.toBe(first.id);
+    });
+  });
+
+  describe("as_label rows", () => {
+    it("adds, updates, and removes rows", () => {
+      const transform = addSection(createRosTransformStep(), "label");
+      const [first] = transform.ros.asLabel;
+
+      const withTwo = addAsLabelRow(transform);
+      expect(withTwo.ros.asLabel).toHaveLength(2);
+
+      const updated = updateAsLabelRow(withTwo, first.id, {
+        key: "speed",
+        value: "data.speed",
+      });
+      expect(updated.ros.asLabel[0]).toMatchObject({
+        key: "speed",
+        value: "data.speed",
+      });
+
+      const removed = removeAsLabelRow(updated, first.id);
+      expect(removed.ros.asLabel).toHaveLength(1);
+      expect(removed.ros.asLabel[0].id).not.toBe(first.id);
+    });
+  });
+
+  describe("hasIncompleteTransform", () => {
+    it("is false when there is no transform", () => {
+      expect(hasIncompleteTransform(undefined)).toBe(false);
+    });
+
+    it("is false with no sections added at all", () => {
+      expect(hasIncompleteTransform(createRosTransformStep())).toBe(false);
+    });
+
+    it("is false for a filter section with a blank topic", () => {
+      const transform = addSection(createRosTransformStep(), "filter");
+      expect(hasIncompleteTransform(transform)).toBe(false);
+    });
+
+    it("is true for an encode row with only the key filled in", () => {
+      let transform = addSection(createRosTransformStep(), "encode");
+      transform = updateEncodeRow(transform, transform.ros.encode[0].id, {
+        key: "data",
+      });
+      expect(hasIncompleteTransform(transform)).toBe(true);
+    });
+
+    it("is true for a label row with only the value filled in", () => {
+      let transform = addSection(createRosTransformStep(), "label");
+      transform = updateAsLabelRow(transform, transform.ros.asLabel[0].id, {
+        value: "data.speed",
+      });
+      expect(hasIncompleteTransform(transform)).toBe(true);
+    });
+
+    it("is false once every row is either complete or fully blank", () => {
+      let transform = addSection(createRosTransformStep(), "encode");
+      transform = updateEncodeRow(transform, transform.ros.encode[0].id, {
+        key: "data",
+        value: "jpeg",
+      });
+      expect(hasIncompleteTransform(transform)).toBe(false);
+    });
+  });
+
+  describe("buildExtPayload", () => {
+    it("returns undefined when there is no transform", () => {
+      expect(buildExtPayload(undefined)).toBeUndefined();
+    });
+
+    it("returns an empty extract when no section is added", () => {
+      expect(buildExtPayload(createRosTransformStep())).toEqual({
+        ros: { extract: {} },
+      });
+    });
+
+    it("includes topic only when the filter section is added and filled", () => {
+      let transform = addSection(createRosTransformStep(), "filter");
+      expect(buildExtPayload(transform)).toEqual({ ros: { extract: {} } });
+
+      transform = updateTopic(transform, "  /robot/odom  ");
+      expect(buildExtPayload(transform)).toEqual({
+        ros: { extract: { topic: "/robot/odom" } },
+      });
+    });
+
+    it("builds the encode map from complete rows, dropping incomplete ones", () => {
+      let transform = addSection(createRosTransformStep(), "encode");
+      const [first] = transform.ros.encode;
+      transform = updateEncodeRow(transform, first.id, {
+        key: "data",
+        value: "jpeg",
+      });
+      transform = addEncodeRow(transform);
+      const [, partial] = transform.ros.encode;
+      transform = updateEncodeRow(transform, partial.id, { key: "other" });
+
+      expect(buildExtPayload(transform)).toEqual({
+        ros: { extract: { encode: { data: "jpeg" } } },
+      });
+    });
+
+    it("builds the as_label map (label name -> path)", () => {
+      let transform = addSection(createRosTransformStep(), "label");
+      const [first] = transform.ros.asLabel;
+      transform = updateAsLabelRow(transform, first.id, {
+        key: "speed",
+        value: "data.speed",
+      });
+
+      expect(buildExtPayload(transform)).toEqual({
+        ros: { extract: { as_label: { speed: "data.speed" } } },
+      });
+    });
+
+    it("includes export fields only when the export section is added", () => {
+      let transform = createRosTransformStep();
+      transform = updateExport(transform, {
+        format: "mcap",
+        duration: "1m",
+        size: "100MB",
+      });
+      expect(buildExtPayload(transform)).toEqual({ ros: { extract: {} } });
+
+      transform = addSection(transform, "export");
+      expect(buildExtPayload(transform)).toEqual({
+        ros: {
+          export: { format: "mcap", duration: "1m", size: "100MB" },
+        },
+      });
+    });
+
+    it("omits blank export fields", () => {
+      let transform = addSection(createRosTransformStep(), "export");
+      transform = updateExport(transform, { format: "", duration: "1m" });
+      expect(buildExtPayload(transform)).toEqual({
+        ros: { export: { duration: "1m" } },
+      });
+    });
+  });
+
+  describe("parseExtPayload", () => {
+    it("succeeds with no transform when ext is undefined", () => {
+      expect(parseExtPayload(undefined)).toEqual({ success: true });
+    });
+
+    it("rejects a non-object ext", () => {
+      expect(parseExtPayload("nope").success).toBe(false);
+      expect(parseExtPayload(null).success).toBe(false);
+    });
+
+    it("rejects ext missing ros", () => {
+      expect(parseExtPayload({}).success).toBe(false);
+    });
+
+    it("succeeds with an empty extract and no sections", () => {
+      const result = parseExtPayload({ ros: { extract: {} } });
+      expect(result.success).toBe(true);
+      expect(result.transform?.ros.sections).toEqual([]);
+    });
+
+    it("parses topic into the filter section", () => {
+      const result = parseExtPayload({
+        ros: { extract: { topic: "/robot/odom" } },
+      });
+      expect(result.success).toBe(true);
+      expect(result.transform?.ros.sections).toEqual(["filter"]);
+      expect(result.transform?.ros.topic).toBe("/robot/odom");
+    });
+
+    it("rejects a non-string topic", () => {
+      expect(parseExtPayload({ ros: { extract: { topic: 5 } } }).success).toBe(
+        false,
+      );
+    });
+
+    it("parses encode into rows", () => {
+      const result = parseExtPayload({
+        ros: { extract: { encode: { data: "jpeg" } } },
+      });
+      expect(result.success).toBe(true);
+      expect(result.transform?.ros.sections).toEqual(["encode"]);
+      expect(result.transform?.ros.encode).toContainEqual(
+        expect.objectContaining({ key: "data", value: "jpeg" }),
+      );
+    });
+
+    it("parses as_label into rows", () => {
+      const result = parseExtPayload({
+        ros: { extract: { as_label: { speed: "data.speed" } } },
+      });
+      expect(result.success).toBe(true);
+      expect(result.transform?.ros.sections).toEqual(["label"]);
+      expect(result.transform?.ros.asLabel).toContainEqual(
+        expect.objectContaining({ key: "speed", value: "data.speed" }),
+      );
+    });
+
+    it("parses export into the export section", () => {
+      const result = parseExtPayload({
+        ros: {
+          extract: {},
+          export: { format: "mcap", duration: "1m", size: "100MB" },
+        },
+      });
+      expect(result.success).toBe(true);
+      expect(result.transform?.ros.sections).toEqual(["export"]);
+      expect(result.transform?.ros.export).toEqual({
+        format: "mcap",
+        duration: "1m",
+        size: "100MB",
+      });
+    });
+
+    it("rejects a malformed export field", () => {
+      expect(parseExtPayload({ ros: { export: { format: 5 } } }).success).toBe(
+        false,
+      );
+    });
+
+    it("round-trips through buildExtPayload", () => {
+      const transform: TransformStepEntry = {
+        kind: "ros",
+        ros: {
+          sections: ["filter", "encode", "label", "export"],
+          topic: "/robot/odom",
+          encode: [{ id: "e1", key: "data", value: "jpeg" }],
+          asLabel: [{ id: "l1", key: "speed", value: "data.speed" }],
+          export: { format: "mcap", duration: "1m", size: "100MB" },
+        },
+      };
+      const payload = buildExtPayload(transform);
+      const parsed = parseExtPayload(payload);
+      expect(parsed.success).toBe(true);
+      expect(buildExtPayload(parsed.transform)).toEqual(payload);
+    });
+  });
+});

--- a/src/Helpers/transformStepBuilder.ts
+++ b/src/Helpers/transformStepBuilder.ts
@@ -259,9 +259,9 @@ export function buildExtPayload(
     if (exportConfig.duration.trim())
       exportPayload.duration = exportConfig.duration.trim();
     if (exportConfig.size.trim()) exportPayload.size = exportConfig.size.trim();
-    if (Object.keys(exportPayload).length > 0) {
-      ros.export = exportPayload;
-    }
+    // Kept even when empty - the section being present is what signals
+    // export mode, not whether its fields happen to be filled in yet.
+    ros.export = exportPayload;
   }
 
   if (Object.keys(ros).length === 0) {
@@ -281,7 +281,7 @@ export function parseExtPayload(ext: unknown): {
     return { success: false };
   }
   const { ros } = ext as Record<string, unknown>;
-  if (typeof ros !== "object" || ros === null) {
+  if (typeof ros !== "object" || ros === null || Array.isArray(ros)) {
     return { success: false };
   }
   const { extract, export: exportRaw } = ros as Record<string, unknown>;
@@ -292,7 +292,11 @@ export function parseExtPayload(ext: unknown): {
   let asLabel: KeyValueRow[] = [];
 
   if (extract !== undefined) {
-    if (typeof extract !== "object" || extract === null) {
+    if (
+      typeof extract !== "object" ||
+      extract === null ||
+      Array.isArray(extract)
+    ) {
       return { success: false };
     }
     const {
@@ -354,7 +358,11 @@ export function parseExtPayload(ext: unknown): {
 
   let exportConfig: RosExportConfig = { format: "", duration: "", size: "" };
   if (exportRaw !== undefined) {
-    if (typeof exportRaw !== "object" || exportRaw === null) {
+    if (
+      typeof exportRaw !== "object" ||
+      exportRaw === null ||
+      Array.isArray(exportRaw)
+    ) {
       return { success: false };
     }
     const { format, duration, size } = exportRaw as Record<string, unknown>;

--- a/src/Helpers/transformStepBuilder.ts
+++ b/src/Helpers/transformStepBuilder.ts
@@ -1,0 +1,385 @@
+export type TransformKind = "ros";
+
+export type RosSection = "filter" | "encode" | "label" | "export";
+
+export interface KeyValueRow {
+  id: string;
+  key: string;
+  value: string;
+}
+
+export interface RosExportConfig {
+  format: string;
+  duration: string;
+  size: string;
+}
+
+export interface RosTransformStep {
+  sections: RosSection[];
+  topic: string;
+  encode: KeyValueRow[];
+  asLabel: KeyValueRow[];
+  export: RosExportConfig;
+}
+
+export interface TransformStepEntry {
+  kind: TransformKind;
+  ros: RosTransformStep;
+}
+
+export const TRANSFORM_BLOCK_ID = "transform";
+
+function blankRow(): KeyValueRow {
+  return { id: crypto.randomUUID(), key: "", value: "" };
+}
+
+export function createRosTransformStep(): TransformStepEntry {
+  return {
+    kind: "ros",
+    ros: {
+      sections: [],
+      topic: "",
+      encode: [],
+      asLabel: [],
+      export: { format: "", duration: "", size: "" },
+    },
+  };
+}
+
+export function addSection(
+  transform: TransformStepEntry,
+  section: RosSection,
+): TransformStepEntry {
+  if (transform.ros.sections.includes(section)) {
+    return transform;
+  }
+  const ros = {
+    ...transform.ros,
+    sections: [...transform.ros.sections, section],
+  };
+  if (section === "encode" && ros.encode.length === 0) {
+    ros.encode = [blankRow()];
+  }
+  if (section === "label" && ros.asLabel.length === 0) {
+    ros.asLabel = [blankRow()];
+  }
+  if (section === "export" && !ros.export.format) {
+    // "mcap" is currently the only supported export format.
+    ros.export = { ...ros.export, format: "mcap" };
+  }
+  return { ...transform, ros };
+}
+
+export function removeSection(
+  transform: TransformStepEntry,
+  section: RosSection,
+): TransformStepEntry {
+  return {
+    ...transform,
+    ros: {
+      ...transform.ros,
+      sections: transform.ros.sections.filter((s) => s !== section),
+    },
+  };
+}
+
+export function updateTopic(
+  transform: TransformStepEntry,
+  topic: string,
+): TransformStepEntry {
+  return { ...transform, ros: { ...transform.ros, topic } };
+}
+
+export function updateExport(
+  transform: TransformStepEntry,
+  changes: Partial<RosExportConfig>,
+): TransformStepEntry {
+  return {
+    ...transform,
+    ros: { ...transform.ros, export: { ...transform.ros.export, ...changes } },
+  };
+}
+
+function addRow(rows: KeyValueRow[]): KeyValueRow[] {
+  return [...rows, blankRow()];
+}
+
+function updateRow(
+  rows: KeyValueRow[],
+  id: string,
+  changes: Partial<Pick<KeyValueRow, "key" | "value">>,
+): KeyValueRow[] {
+  return rows.map((row) => (row.id === id ? { ...row, ...changes } : row));
+}
+
+function removeRow(rows: KeyValueRow[], id: string): KeyValueRow[] {
+  return rows.filter((row) => row.id !== id);
+}
+
+export function addEncodeRow(
+  transform: TransformStepEntry,
+): TransformStepEntry {
+  return {
+    ...transform,
+    ros: { ...transform.ros, encode: addRow(transform.ros.encode) },
+  };
+}
+
+export function updateEncodeRow(
+  transform: TransformStepEntry,
+  id: string,
+  changes: Partial<Pick<KeyValueRow, "key" | "value">>,
+): TransformStepEntry {
+  return {
+    ...transform,
+    ros: {
+      ...transform.ros,
+      encode: updateRow(transform.ros.encode, id, changes),
+    },
+  };
+}
+
+export function removeEncodeRow(
+  transform: TransformStepEntry,
+  id: string,
+): TransformStepEntry {
+  return {
+    ...transform,
+    ros: { ...transform.ros, encode: removeRow(transform.ros.encode, id) },
+  };
+}
+
+export function addAsLabelRow(
+  transform: TransformStepEntry,
+): TransformStepEntry {
+  return {
+    ...transform,
+    ros: { ...transform.ros, asLabel: addRow(transform.ros.asLabel) },
+  };
+}
+
+export function updateAsLabelRow(
+  transform: TransformStepEntry,
+  id: string,
+  changes: Partial<Pick<KeyValueRow, "key" | "value">>,
+): TransformStepEntry {
+  return {
+    ...transform,
+    ros: {
+      ...transform.ros,
+      asLabel: updateRow(transform.ros.asLabel, id, changes),
+    },
+  };
+}
+
+export function removeAsLabelRow(
+  transform: TransformStepEntry,
+  id: string,
+): TransformStepEntry {
+  return {
+    ...transform,
+    ros: { ...transform.ros, asLabel: removeRow(transform.ros.asLabel, id) },
+  };
+}
+
+function isCompleteRow(row: KeyValueRow): boolean {
+  return row.key.trim() !== "" && row.value.trim() !== "";
+}
+
+function hasPartialRow(rows: KeyValueRow[]): boolean {
+  return rows.some(
+    (row) => (row.key.trim() !== "") !== (row.value.trim() !== ""),
+  );
+}
+
+export function hasIncompleteTransform(
+  transform: TransformStepEntry | undefined,
+): boolean {
+  if (!transform) {
+    return false;
+  }
+  const { sections, encode, asLabel } = transform.ros;
+  if (sections.includes("encode") && hasPartialRow(encode)) {
+    return true;
+  }
+  if (sections.includes("label") && hasPartialRow(asLabel)) {
+    return true;
+  }
+  return false;
+}
+
+function rowsToMap(rows: KeyValueRow[]): Record<string, string> {
+  return Object.fromEntries(
+    rows.filter(isCompleteRow).map((row) => [row.key.trim(), row.value.trim()]),
+  );
+}
+
+export function buildExtPayload(
+  transform: TransformStepEntry | undefined,
+): Record<string, unknown> | undefined {
+  if (!transform) {
+    return undefined;
+  }
+  const {
+    sections,
+    topic,
+    encode,
+    asLabel,
+    export: exportConfig,
+  } = transform.ros;
+
+  const extract: Record<string, unknown> = {};
+  if (sections.includes("filter") && topic.trim()) {
+    extract.topic = topic.trim();
+  }
+  if (sections.includes("encode")) {
+    const encodeMap = rowsToMap(encode);
+    if (Object.keys(encodeMap).length > 0) {
+      extract.encode = encodeMap;
+    }
+  }
+  if (sections.includes("label")) {
+    const asLabelMap = rowsToMap(asLabel);
+    if (Object.keys(asLabelMap).length > 0) {
+      extract.as_label = asLabelMap;
+    }
+  }
+
+  const ros: Record<string, unknown> = {};
+  // The server only accepts one of extract/export/transform per request, so
+  // extract is only ever included when a filter/encode/label section is
+  // actually contributing something to it.
+  if (Object.keys(extract).length > 0) {
+    ros.extract = extract;
+  }
+  if (sections.includes("export")) {
+    const exportPayload: Record<string, unknown> = {};
+    if (exportConfig.format.trim())
+      exportPayload.format = exportConfig.format.trim();
+    if (exportConfig.duration.trim())
+      exportPayload.duration = exportConfig.duration.trim();
+    if (exportConfig.size.trim()) exportPayload.size = exportConfig.size.trim();
+    if (Object.keys(exportPayload).length > 0) {
+      ros.export = exportPayload;
+    }
+  }
+
+  if (Object.keys(ros).length === 0) {
+    return { ros: { extract: {} } };
+  }
+  return { ros };
+}
+
+export function parseExtPayload(ext: unknown): {
+  success: boolean;
+  transform?: TransformStepEntry;
+} {
+  if (ext === undefined) {
+    return { success: true };
+  }
+  if (typeof ext !== "object" || ext === null) {
+    return { success: false };
+  }
+  const { ros } = ext as Record<string, unknown>;
+  if (typeof ros !== "object" || ros === null) {
+    return { success: false };
+  }
+  const { extract, export: exportRaw } = ros as Record<string, unknown>;
+
+  const sections: RosSection[] = [];
+  let topic = "";
+  let encode: KeyValueRow[] = [];
+  let asLabel: KeyValueRow[] = [];
+
+  if (extract !== undefined) {
+    if (typeof extract !== "object" || extract === null) {
+      return { success: false };
+    }
+    const {
+      topic: topicRaw,
+      encode: encodeRaw,
+      as_label: asLabelRaw,
+    } = extract as Record<string, unknown>;
+
+    if (topicRaw !== undefined) {
+      if (typeof topicRaw !== "string") {
+        return { success: false };
+      }
+      sections.push("filter");
+      topic = topicRaw;
+    }
+
+    if (encodeRaw !== undefined) {
+      if (
+        typeof encodeRaw !== "object" ||
+        encodeRaw === null ||
+        Array.isArray(encodeRaw)
+      ) {
+        return { success: false };
+      }
+      sections.push("encode");
+      encode = Object.entries(encodeRaw as Record<string, unknown>).map(
+        ([key, value]) => ({
+          id: crypto.randomUUID(),
+          key,
+          value: typeof value === "string" ? value : String(value),
+        }),
+      );
+      if (encode.length === 0) {
+        encode = [blankRow()];
+      }
+    }
+
+    if (asLabelRaw !== undefined) {
+      if (
+        typeof asLabelRaw !== "object" ||
+        asLabelRaw === null ||
+        Array.isArray(asLabelRaw)
+      ) {
+        return { success: false };
+      }
+      sections.push("label");
+      asLabel = Object.entries(asLabelRaw as Record<string, unknown>).map(
+        ([key, value]) => ({
+          id: crypto.randomUUID(),
+          key,
+          value: typeof value === "string" ? value : String(value),
+        }),
+      );
+      if (asLabel.length === 0) {
+        asLabel = [blankRow()];
+      }
+    }
+  }
+
+  let exportConfig: RosExportConfig = { format: "", duration: "", size: "" };
+  if (exportRaw !== undefined) {
+    if (typeof exportRaw !== "object" || exportRaw === null) {
+      return { success: false };
+    }
+    const { format, duration, size } = exportRaw as Record<string, unknown>;
+    if (format !== undefined && typeof format !== "string") {
+      return { success: false };
+    }
+    if (duration !== undefined && typeof duration !== "string") {
+      return { success: false };
+    }
+    if (size !== undefined && typeof size !== "string") {
+      return { success: false };
+    }
+    sections.push("export");
+    exportConfig = {
+      format: (format as string) ?? "",
+      duration: (duration as string) ?? "",
+      size: (size as string) ?? "",
+    };
+  }
+
+  return {
+    success: true,
+    transform: {
+      kind: "ros",
+      ros: { sections, topic, encode, asLabel, export: exportConfig },
+    },
+  };
+}

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -291,7 +291,7 @@ describe("EntryDetail", () => {
     // The default query has no conditions of its own, so Label filter (a
     // step like Sample/Limit) has to be added from the menu before there's
     // a row to interact with.
-    const addWhereLabels = async () => {
+    const addLabelFilter = async () => {
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Add step"));
       });
@@ -305,7 +305,7 @@ describe("EntryDetail", () => {
     });
 
     it("reparses losslessly when returning to Builder without touching the JSON", async () => {
-      await addWhereLabels();
+      await addLabelFilter();
       const labelInput = screen.getByRole("combobox", { name: "Label" });
       fireEvent.change(labelInput, { target: { value: "status" } });
       fireEvent.change(screen.getByPlaceholderText("value"), {
@@ -367,7 +367,7 @@ describe("EntryDetail", () => {
     });
 
     it("blocks Run Query and shows an error when a condition row is missing its value", async () => {
-      await addWhereLabels();
+      await addLabelFilter();
       const labelInput = screen.getByRole("combobox", { name: "Label" });
       fireEvent.change(labelInput, { target: { value: "status" } });
 

--- a/src/Views/BucketPanel/EntryDetail.test.tsx
+++ b/src/Views/BucketPanel/EntryDetail.test.tsx
@@ -288,7 +288,7 @@ describe("EntryDetail", () => {
       return textArea;
     };
 
-    // The default query has no conditions of its own, so Where labels (a
+    // The default query has no conditions of its own, so Label filter (a
     // step like Sample/Limit) has to be added from the menu before there's
     // a row to interact with.
     const addWhereLabels = async () => {
@@ -296,19 +296,17 @@ describe("EntryDetail", () => {
         fireEvent.click(screen.getByLabelText("Add step"));
       });
       await act(async () => {
-        fireEvent.click(screen.getByText("Where labels"));
+        fireEvent.click(screen.getByText("Label filter"));
       });
     };
 
-    it("starts in Builder mode, ready to add a Where labels block", () => {
+    it("starts in Builder mode, ready to add a Label filter block", () => {
       expect(screen.getByLabelText("Add step")).not.toBeDisabled();
     });
 
     it("reparses losslessly when returning to Builder without touching the JSON", async () => {
       await addWhereLabels();
-      const labelInput = container.querySelector(
-        ".ant-select-auto-complete input",
-      ) as HTMLElement;
+      const labelInput = screen.getByRole("combobox", { name: "Label" });
       fireEvent.change(labelInput, { target: { value: "status" } });
       fireEvent.change(screen.getByPlaceholderText("value"), {
         target: { value: "active" },
@@ -317,7 +315,7 @@ describe("EntryDetail", () => {
       fireEvent.click(screen.getByRole("switch"));
       fireEvent.click(screen.getByRole("switch"));
 
-      expect(screen.getByText("Where labels")).toBeTruthy();
+      expect(screen.getByText("Label filter")).toBeTruthy();
       expect(screen.getByPlaceholderText("value")).toHaveValue("active");
     });
 
@@ -326,7 +324,7 @@ describe("EntryDetail", () => {
 
       fireEvent.click(screen.getByRole("switch"));
       // Still in JSON mode: the switch is deferred behind the confirmation.
-      expect(screen.queryByText("Where labels")).toBeNull();
+      expect(screen.queryByText("Label filter")).toBeNull();
       expect(screen.getByText(/completely reset the builder/)).toBeTruthy();
     });
 
@@ -338,7 +336,7 @@ describe("EntryDetail", () => {
 
       // The reset goes back to the app's zero-condition default, so Where
       // labels (added just for the edited "&status" condition) is gone too.
-      expect(screen.queryByText("Where labels")).toBeNull();
+      expect(screen.queryByText("Label filter")).toBeNull();
       expect(screen.queryByPlaceholderText("value")).toBeNull();
     });
 
@@ -364,19 +362,13 @@ describe("EntryDetail", () => {
       fireEvent.click(screen.getByRole("switch"));
       fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
-      expect(screen.queryByText("Where labels")).toBeNull();
+      expect(screen.queryByText("Label filter")).toBeNull();
       expect(textArea.value).toBe('{"&status": {"$eq": "active"}}');
     });
 
     it("blocks Run Query and shows an error when a condition row is missing its value", async () => {
       await addWhereLabels();
-      // The label field is an AutoComplete: antd renders its placeholder as
-      // a decorative overlay rather than a native `placeholder` attribute,
-      // so it has to be targeted by its distinguishing class instead.
-      const labelInput = container.querySelector(
-        ".ant-select-auto-complete input",
-      ) as HTMLElement;
-      expect(labelInput).not.toBeNull();
+      const labelInput = screen.getByRole("combobox", { name: "Label" });
       fireEvent.change(labelInput, { target: { value: "status" } });
 
       (bucket.query as Mock).mockClear();
@@ -444,7 +436,7 @@ describe("EntryDetail", () => {
 
         await loadSavedQuery("json-saved");
 
-        expect(screen.queryByText("Where labels")).toBeNull();
+        expect(screen.queryByText("Label filter")).toBeNull();
         const monacoEditor = container.querySelector(".monaco-editor-mock");
         const textArea = monacoEditor!.querySelector(
           "textarea",
@@ -466,7 +458,7 @@ describe("EntryDetail", () => {
 
         await loadSavedQuery("builder-saved");
 
-        expect(screen.getByText("Where labels")).toBeTruthy();
+        expect(screen.getByText("Label filter")).toBeTruthy();
         expect(screen.getByPlaceholderText("value")).toHaveValue("active");
       });
 
@@ -481,7 +473,7 @@ describe("EntryDetail", () => {
 
         await loadSavedQuery("legacy-saved");
 
-        expect(screen.getByText("Where labels")).toBeTruthy();
+        expect(screen.getByText("Label filter")).toBeTruthy();
       });
 
       it("keeps Save disabled for an untouched query saved before mode was tracked", async () => {


### PR DESCRIPTION
# Add Transform (ReductROS) step to the Conditional Query builder

Closes #238, closes #245

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Adds a "Transform (ReductROS)" step to the Data Explorer's Conditional Query builder, invoking ReductStore's ReductROS extension to decode ROS messages at query time. Also fixes a couple of pre-existing builder bugs found during review.

**Process (ROS) step**
- Four independently addable sections, added via a single "+" dropdown: **Filter** (optional topic filter), **Encode** (binary field → base64/jpeg, supports multiple rows), **As label** (extracted field → computed label, filterable via `@label`, supports multiple rows), **Export** (MCAP episode export: format/duration/size)
- Filter/Encode/As label populate `ext.ros.extract`; Export populates `ext.ros.export`. The two are mutually exclusive per the server's own validation — the "+" menu always shows all four options, greying out whichever isn't currently available with a tooltip explaining why, rather than hiding them
- The extension payload is merged into the same JSON text as the `when` condition, under a `#ext` key, so Builder and JSON mode stay in sync and Save/Load requires no extra state
- No client-side license gating — an unlicensed/Core server's rejection surfaces through the existing error-handling path, consistent with how the rest of the builder already treats server-side validation
- Manually verified against a live ReductStore Pro server: topic filtering, field-to-label extraction, and binary field encoding all confirmed working

**Builder-wide alignment pass**
- Every step card's title now sits on its own line, with row labels (Interval, Filter, Encode, As label, Where, Count, Step) aligned in a shared column via constants in `stepRowLayout.ts` instead of per-file literals
- The "+ Add step" menu got the same always-show/grey-out-with-tooltip treatment as the Process (ROS) section's menu

**Bug fixes (closes #245)**
- The Interval field's "resolves to X" preview was reusing the interval from the last completed query run instead of recomputing it for the currently selected time range, so it could show a stale value after changing the range without re-running — it now always reflects the live range
- The Interval field is now an autocomplete offering common durations (`$__interval`, `1s`, `2s`, …) while still accepting a custom value; retyping `$__interval` by hand now re-enables the macro instead of getting stuck off
- The default Interval step now shows even before a bucket/entry is selected, matching the app's default query

### Related issues

Closes #238, closes #245

### Does this PR introduce a breaking change?

No.

### Other information

None.